### PR TITLE
Refactor terminal widget into window

### DIFF
--- a/index.html
+++ b/index.html
@@ -618,82 +618,44 @@
       transform: translateX(-50%) translateY(-4px);
     }
 
-    /* --- Dashboard Widget (Terminal Style) --- */
-    .dashboard-widget {
-      position: fixed;
-      bottom: 100px;
-      right: 20px;
-      width: 280px;
+    /* --- Terminal Window --- */
+    .terminal-window {
+      width: 320px;
+      top: 520px;
+      right: 80px;
+      z-index: 8;
       background: rgba(40, 44, 52, 0.95);
-      backdrop-filter: blur(12px);
       border: 1px solid #21252b;
-      border-radius: 8px;
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-      z-index: 999;
       font-family: 'SF Mono', Consolas, Monaco, 'Courier New', monospace;
-      transition:
-        width 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
-        height 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
-        border-radius 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
-        bottom 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
-        left 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
-        right 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
     }
 
-    .dashboard-titlebar {
+    .terminal-window .window-titlebar {
       background: #21252b;
-      padding: 8px 12px;
-      display: flex;
-      align-items: center;
-      gap: 8px;
       border-bottom: 1px solid #181a1f;
-      border-radius: 7px 7px 0 0;
-      transition:
-        background-color 0.3s ease,
-        border 0.3s ease,
-        padding 0.3s ease;
+      justify-content: flex-start;
+      gap: 12px;
     }
 
-    .terminal-dots {
-      display: flex;
+    .terminal-window .window-controls {
       gap: 6px;
-      align-items: center;
+      padding-right: 0;
     }
 
-    .terminal-dot {
-      width: 10px;
-      height: 10px;
-      border-radius: 50%;
-    }
-
-    .terminal-dot.red { background: #ff5f56; }
-    .terminal-dot.yellow { background: #ffbd2e; }
-    .terminal-dot.green { background: #27c93f; }
-
-    .dashboard-title {
+    .terminal-window .window-title {
+      color: #abb2bf;
       font-size: 12px;
       font-weight: 500;
-      color: #abb2bf;
       letter-spacing: 0.3px;
-      margin-left: 4px;
-      opacity: 1;
-      visibility: visible;
-      transition:
-        opacity 0.25s ease-out,
-        visibility 0.25s ease-out,
-        max-width 0.25s ease-out;
+      text-align: left;
     }
 
-    .dashboard-content {
-      padding: 14px;
+    .terminal-window .window-content {
+      background: transparent;
+      padding: 18px;
       color: #abb2bf;
       font-size: 12px;
       line-height: 1.6;
-      opacity: 1;
-      visibility: visible;
-      transition:
-        opacity 0.25s ease-out,
-        visibility 0.25s ease-out;
     }
 
     .terminal-prompt {
@@ -733,9 +695,6 @@
       background: #98c379;
       margin-left: 2px;
       opacity: 1;
-    }
-
-    .dashboard-widget:hover .terminal-cursor {
       animation: blink 1s step-end infinite;
     }
 
@@ -898,53 +857,6 @@
         width: 160px;
       }
 
-      .dashboard-widget {
-        bottom: 100px;
-        right: 10px;
-        left: 10px;
-        width: auto;
-        cursor: pointer;
-      }
-
-      /* Collapsed state for mobile scroll */
-      .dashboard-widget.collapsed {
-        width: 50px;
-        height: 50px;
-        border-radius: 25px;
-        bottom: 270px;
-        left: 20px;
-        right: auto;
-        padding: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-
-      .dashboard-widget.collapsed .dashboard-content {
-        opacity: 0;
-        visibility: hidden;
-        pointer-events: none;
-      }
-
-      .dashboard-widget.collapsed .dashboard-title {
-        opacity: 0;
-        visibility: hidden;
-        max-width: 0;
-        overflow: hidden;
-      }
-
-      .dashboard-widget.collapsed .dashboard-titlebar {
-        background: transparent;
-        border: none;
-        padding: 0;
-        border-radius: 25px;
-        width: 50px;
-        height: 50px;
-        gap: 0;
-        justify-content: center;
-        align-items: center;
-      }
-
       .dock {
         gap: 8px;
         padding: 6px 12px;
@@ -981,14 +893,6 @@
 
       .dock-divider {
         height: 36px;
-      }
-
-      .dashboard-widget {
-        font-size: 11px;
-      }
-
-      .terminal-status {
-        font-size: 11px;
       }
 
       .phone-mockup {
@@ -1029,6 +933,34 @@
         <div class="avatar-info">
           <div class="avatar-name">Rhea Singh</div>
           <div class="avatar-subtitle">Software Engineer · Product/UX</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Terminal Window -->
+    <div class="window terminal-window">
+      <div class="window-titlebar">
+        <div class="window-controls">
+          <div class="window-button close"></div>
+          <div class="window-button minimize"></div>
+          <div class="window-button maximize"></div>
+        </div>
+        <div class="window-title">terminal</div>
+      </div>
+      <div class="window-content">
+        <div class="terminal-prompt">$ status --now</div>
+        <div class="terminal-status">
+          <span class="terminal-bullet">◉</span>
+          <span class="terminal-label">working_on</span>
+          <span class="terminal-value">the crossword</span>
+        </div>
+        <div class="terminal-status">
+          <span class="terminal-bullet">◉</span>
+          <span class="terminal-label">reading</span>
+          <span class="terminal-value">Dune Messiah</span>
+        </div>
+        <div style="margin-top: 8px; color: #5c6370;">
+          $<span class="terminal-cursor"></span>
         </div>
       </div>
     </div>
@@ -1286,34 +1218,6 @@
       </div>
     </div>
 
-    <!-- Dashboard Widget (Terminal) -->
-    <div class="dashboard-widget">
-      <div class="dashboard-titlebar">
-        <div class="terminal-dots">
-          <div class="terminal-dot red"></div>
-          <div class="terminal-dot yellow"></div>
-          <div class="terminal-dot green"></div>
-        </div>
-        <div class="dashboard-title">terminal</div>
-      </div>
-      <div class="dashboard-content">
-        <div class="terminal-prompt">$ status --now</div>
-        <div class="terminal-status">
-          <span class="terminal-bullet">◉</span>
-          <span class="terminal-label">working_on</span>
-          <span class="terminal-value">the crossword</span>
-        </div>
-        <div class="terminal-status">
-          <span class="terminal-bullet">◉</span>
-          <span class="terminal-label">reading</span>
-          <span class="terminal-value">Dune Messiah</span>
-        </div>
-        <div style="margin-top: 8px; color: #5c6370;">
-          $<span class="terminal-cursor"></span>
-        </div>
-      </div>
-    </div>
-
     <!-- Dock Container -->
     <div style="position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%); display: flex; gap: 12px; z-index: 1000;">
       <!-- Projects Dock -->
@@ -1521,39 +1425,6 @@
       }
     }
 
-    // Mobile terminal widget collapse on scroll
-    (function() {
-      // Only apply on mobile screens
-      if (window.innerWidth > 1024) return;
-
-      const widget = document.querySelector('.dashboard-widget');
-      if (!widget) return;
-
-      let isExpanded = true;
-
-      // Collapse on scroll
-      window.addEventListener('scroll', function() {
-        if (isExpanded) {
-          widget.classList.add('collapsed');
-          isExpanded = false;
-        }
-      });
-
-      // Toggle on click/tap
-      widget.addEventListener('click', function(e) {
-        e.stopPropagation();
-        widget.classList.toggle('collapsed');
-        isExpanded = !widget.classList.contains('collapsed');
-      });
-
-      // Re-check on resize
-      window.addEventListener('resize', function() {
-        if (window.innerWidth > 1024) {
-          widget.classList.remove('collapsed');
-          isExpanded = true;
-        }
-      });
-    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the floating dashboard terminal widget with a standard window component
- position the terminal window directly under the FaceTime window so it participates in the stacked mobile layout
- remove the mobile-specific collapse styling and script now that the terminal behaves like other windows

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e283870274832e83600ee0f3c9070e