### PR TITLE
Reposition project window action buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -729,10 +729,10 @@
     }
 
     .project-actions {
-      margin-top: 16px;
+      margin: 12px 0 20px;
       display: flex;
       align-items: center;
-      justify-content: center;
+      justify-content: flex-start;
       gap: 10px;
     }
 
@@ -1207,6 +1207,18 @@
         <p style="font-size: 13px; line-height: 1.6; color: var(--text-dark); margin-bottom: 12px;">
           A real-time interactive version of the New York Times Spelling Bee made to compete with friends and family. Updates daily when the new puzzle drops.
         </p>
+        <div class="project-actions">
+          <a href="https://frankies-spelling-bee.vercel.app" class="project-launch" target="_blank">
+            <span>Launch</span>
+            <span aria-hidden="true">🚀</span>
+          </a>
+          <a href="https://github.com/rhea-s/spelling-bee/tree/main" class="project-icon-link" target="_blank" aria-label="View project on GitHub">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.52 2.87 8.36 6.84 9.72.5.1.68-.22.68-.49 0-.24-.01-.87-.01-1.71-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.1-1.5-1.1-1.5-.9-.63.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.37-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.3 9.3 0 0 1 5 0c1.9-1.32 2.74-1.05 2.74-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.06.36.33.68.97.68 1.96 0 1.42-.01 2.56-.01 2.9 0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2Z" fill="currentColor" />
+            </svg>
+            <span class="sr-only">View on GitHub</span>
+          </a>
+        </div>
         <div class="section-heading">Tech Stack</div>
         <div class="skill-tags" style="margin-bottom: 16px;">
           <span class="skill-tag">JavaScript</span>
@@ -1231,19 +1243,6 @@
               <img src="assets/spellingbee-ex2.PNG" alt="Spelling Bee Screenshot 2" />
             </div>
           </div>
-        </div>
-
-        <div class="project-actions">
-          <a href="https://frankies-spelling-bee.vercel.app" class="project-launch" target="_blank">
-            <span>Launch</span>
-            <span aria-hidden="true">🚀</span>
-          </a>
-          <a href="https://github.com/rhea-s/spelling-bee/tree/main" class="project-icon-link" target="_blank" aria-label="View project on GitHub">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.52 2.87 8.36 6.84 9.72.5.1.68-.22.68-.49 0-.24-.01-.87-.01-1.71-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.1-1.5-1.1-1.5-.9-.63.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.37-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.3 9.3 0 0 1 5 0c1.9-1.32 2.74-1.05 2.74-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.06.36.33.68.97.68 1.96 0 1.42-.01 2.56-.01 2.9 0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2Z" fill="currentColor" />
-            </svg>
-            <span class="sr-only">View on GitHub</span>
-          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- move the project window Launch and GitHub buttons into the Project Overview section
- adjust the project action layout so the buttons align with the overview content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e2216154832e80b8bd7b8ed0d3cc