### PR TITLE
Fix FaceTime window hover effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,7 +189,8 @@
     }
 
     .facetime-window:hover {
-      transform: translateX(-50%) translateY(-2px);
+      transform: translateX(-50%);
+      box-shadow: var(--window-shadow);
     }
 
     .facetime-content {


### PR DESCRIPTION
## Summary
- stop the FaceTime window from shifting or scaling on hover by preserving its base transform
- keep other windows using the existing hover animation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e334371184832ebee91f5e1ad7d7f6