### PR TITLE
Add pupil backdrop styling for avatar stage

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,6 +221,19 @@
       pointer-events: none;
     }
 
+    .pupil-backdrop {
+      position: absolute;
+      top: 44%;
+      left: 50%;
+      width: 46%;
+      height: 22%;
+      background: #fff;
+      transform: translate(-50%, -50%);
+      border-radius: 12px;
+      z-index: 0;
+      pointer-events: none;
+    }
+
     .pupil {
       position: absolute;
       z-index: 1;
@@ -1188,6 +1201,7 @@
       </div>
       <div class="window-content facetime-content">
         <div class="avatar-stage" id="stage">
+          <div class="pupil-backdrop"></div>
           <div class="pupil left" id="pupilL"></div>
           <div class="pupil right" id="pupilR"></div>
           <img class="avatar" id="avatarImg" src="assets/avatar_no-eyes.png" alt="Rhea Singh avatar" />


### PR DESCRIPTION
## Summary
- add a white pupil backdrop element beneath the avatar pupils while keeping existing layering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e33436a5c0832e92b0b6f415f2b932