### PR TITLE
Revamp FaceTime location badge styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,38 +376,41 @@
 
     /* --- Location Footer (integrated into FaceTime window) --- */
     .location-footer {
-      padding: 10px 16px;
-      background: white;
-      border-top: 1px solid var(--pink-border);
+      padding: 14px 16px 16px;
       text-align: center;
-      font-size: 12px;
-      font-weight: 500;
-      color: var(--text-muted);
-      letter-spacing: 0.2px;
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 6px;
       position: relative;
       z-index: 1;
     }
 
+    .location-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 9px 18px;
+      background: linear-gradient(135deg, rgba(255, 244, 249, 0.95), rgba(252, 227, 237, 0.95));
+      border-radius: 999px;
+      box-shadow: 0 6px 18px rgba(74, 14, 61, 0.12);
+      color: var(--text-dark);
+      font-size: 13px;
+      font-weight: 600;
+      letter-spacing: 0.2px;
+    }
+
     .online-indicator {
-      width: 8px;
-      height: 8px;
+      width: 10px;
+      height: 10px;
       border-radius: 50%;
       background: #27c93f;
-      box-shadow: 0 0 0 2px rgba(39, 201, 63, 0.2);
+      box-shadow: 0 0 0 3px rgba(39, 201, 63, 0.18);
       animation: pulse 2s ease-in-out infinite;
     }
 
     @keyframes pulse {
-      0%, 100% {
-        box-shadow: 0 0 0 2px rgba(39, 201, 63, 0.2);
-      }
-      50% {
-        box-shadow: 0 0 0 4px rgba(39, 201, 63, 0.1);
-      }
+      0%, 100% { box-shadow: 0 0 0 3px rgba(39, 201, 63, 0.18); }
+      50% { box-shadow: 0 0 0 5px rgba(39, 201, 63, 0.12); }
     }
 
     /* --- About/Education Window --- */
@@ -1162,8 +1165,13 @@
       }
 
       .location-footer {
-        font-size: 10px;
-        padding: 8px 12px;
+        padding: 12px 12px 14px;
+      }
+
+      .location-badge {
+        font-size: 12px;
+        padding: 8px 16px;
+        gap: 8px;
       }
 
       .experience-window,
@@ -1274,8 +1282,10 @@
         </div>
         <!-- Location Footer -->
         <div class="location-footer">
-          <span class="online-indicator"></span>
-          Open to roles in <span id="sfLocation">SF</span>|<span id="nycLocation">NYC</span>|<span id="nonusLocation">Remote or non-US</span>
+          <span class="location-badge">
+            <span class="online-indicator"></span>
+            Open to roles in <span id="sfLocation">SF</span>|<span id="nycLocation">NYC</span>|<span id="nonusLocation">Remote or non-US</span>
+          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- wrap the FaceTime location footer copy and online indicator in a new badge container for focused styling
- refresh the footer layout with centered spacing and add a pink gradient pill treatment to the badge
- enlarge the online indicator and tune animations for better visibility inside the badge, including responsive adjustments

## Testing
- Manual verification in browser (day and night themes)


------
https://chatgpt.com/codex/tasks/task_e_68e33525bb04832eaf9d624f4548c280