### PR TITLE
Adjust pupil backdrop width to avoid overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,7 +276,7 @@
       position: absolute;
       top: 44%;
       left: 50%;
-      width: 46%;
+      width: calc(46% - 40px);
       height: 22%;
       background: #fff;
       transform: translate(-50%, -50%);


### PR DESCRIPTION
## Summary
- shrink the FaceTime pupil backdrop width by 40px overall while keeping it centered to avoid peeking past avatar edges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e337bae560832eb8c3cfbbfd2e8d26