### PR TITLE
Isolate avatar stacking context for pupil backdrop

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,6 +249,7 @@
     .avatar-stage {
       position: relative;
       z-index: 1;
+      isolation: isolate;
       aspect-ratio: 8/7;
       display: grid;
       place-items: center;
@@ -281,7 +282,7 @@
       background: #fff;
       transform: translate(-50%, -50%);
       border-radius: 12px;
-      z-index: 0;
+      z-index: -1;
       pointer-events: none;
     }
 


### PR DESCRIPTION
## Summary
- isolate the avatar stage so its children z-index values render within their own stacking context
- push the pupil backdrop behind the pupils while keeping it contained within the avatar mask
- manually verify day/night and location transitions to ensure the backdrop stays hidden beneath the avatar during animations

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68e337be3944832e8838ade1845a4e69