### PR TITLE
Adjust FaceTime window transition background

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,6 +186,7 @@
       left: 50%;
       transform: translateX(-50%);
       z-index: 10;
+      background: #1c1c1e;
     }
 
     .facetime-window:hover {
@@ -197,6 +198,7 @@
       padding: 0;
       width: 100%;
       position: relative;
+      background-color: #1c1c1e;
     }
 
     .facetime-content::before {
@@ -210,6 +212,7 @@
       background-size: cover;
       background-position: center;
       background-repeat: no-repeat;
+      background-color: #1c1c1e;
       z-index: 0;
       clip-path: circle(150% at 50% 40%);
     }


### PR DESCRIPTION
## Summary
- set a dark charcoal background for the FaceTime window container and transition layer
- ensure the iris animation no longer shows a white flash when swapping backgrounds

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68e339bc0de4832e83a1c6cfb6db308d