### PR TITLE
Remove hover scaling from avatar in FaceTime window

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,11 +269,6 @@
       transform: translateY(-40px);
       display: block;
       cursor: pointer;
-      transition: transform 0.2s ease;
-    }
-
-    .avatar:hover {
-      transform: translateY(-40px) scale(1.02);
     }
 
     .pupil-backdrop {


### PR DESCRIPTION
## Summary
- remove the FaceTime avatar hover rule that increased the image size
- drop the transform transition so the avatar dimensions stay consistent when hovered

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e33dc5afb4832eba05050604bd857f