### PR TITLE
Restore pupil backdrop masking during transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,7 +210,7 @@
       background-size: cover;
       background-position: center;
       background-repeat: no-repeat;
-      z-index: 0;
+      z-index: -1;
       clip-path: circle(150% at 50% 40%);
     }
 
@@ -248,7 +248,8 @@
 
     .avatar-stage {
       position: relative;
-      z-index: 1;
+      z-index: 0;
+      isolation: isolate;
       aspect-ratio: 8/7;
       display: grid;
       place-items: center;
@@ -281,7 +282,7 @@
       background: #fff;
       transform: translate(-50%, -50%);
       border-radius: 12px;
-      z-index: 0;
+      z-index: -1;
       pointer-events: none;
     }
 


### PR DESCRIPTION
## Summary
- keep the FaceTime window background pseudo-element behind the avatar stage so the mask stays intact
- zero out the avatar stage z-index while retaining its isolated stacking context so the pupil backdrop cannot bleed through during theme/location animations

## Testing
- Manual verification


------
https://chatgpt.com/codex/tasks/task_e_68e337be3944832e8838ade1845a4e69