### PR TITLE
Add night mode styling for FaceTime speech bubble

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,6 +349,13 @@
       white-space: nowrap;
     }
 
+    .speech-bubble--night {
+      background: rgba(32, 27, 44, 0.95);
+      color: rgba(255, 255, 255, 0.92);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+    }
+
     @keyframes bubbleFadeIn {
       from {
         opacity: 0;
@@ -2201,9 +2208,19 @@
     (function () {
       const toggle = document.getElementById('themeToggle');
       const speechBubble = document.querySelector('.speech-bubble');
+      const applySpeechBubbleTheme = () => {
+        if (!speechBubble) return;
+        if (isDayMode) {
+          speechBubble.classList.remove('speech-bubble--night');
+        } else {
+          speechBubble.classList.add('speech-bubble--night');
+        }
+      };
 
       // Check if reduced motion is preferred
       const motionOK = !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+      applySpeechBubbleTheme();
 
       toggle.addEventListener('click', function(e) {
         e.stopPropagation(); // Prevent triggering window click-to-front
@@ -2219,10 +2236,12 @@
             speechBubble.textContent = isDayMode ? 'hello world!' : 'gn, world :)';
             // Fade down and in
             speechBubble.style.animation = 'bubbleFadeDown 0.3s ease-out forwards';
+            applySpeechBubbleTheme();
           }, 300);
         } else if (speechBubble) {
           // No animation, just change text
           speechBubble.textContent = isDayMode ? 'hello world!' : 'gn, world :)';
+          applySpeechBubbleTheme();
         }
 
         // Update toggle state


### PR DESCRIPTION
## Summary
- add a dedicated night-mode style for the FaceTime speech bubble
- toggle the bubble's theme class when switching between day and night modes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e359985318832e9c532e90a570758b