### PR TITLE
Add avatar loading overlay and asset preload coordination

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,6 +205,54 @@
       background-color: #1c1c1e;
     }
 
+    .avatar-loading {
+      position: absolute;
+      inset: 0;
+      z-index: 3;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      background: rgba(12, 12, 16, 0.82);
+      color: rgba(255, 255, 255, 0.92);
+      font-size: 14px;
+      letter-spacing: 0.2px;
+      transition: opacity 180ms ease;
+    }
+
+    .avatar-loading.is-hidden {
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+    }
+
+    .avatar-spinner {
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      border: 3px solid rgba(255, 255, 255, 0.25);
+      border-top-color: rgba(255, 255, 255, 0.9);
+      animation: avatarSpin 1s linear infinite;
+    }
+
+    @keyframes avatarSpin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
     .facetime-content::before {
       content: '';
       position: absolute;
@@ -1303,6 +1351,10 @@
       </div>
       <div class="window-content facetime-content">
         <div class="avatar-stage" id="stage">
+          <div class="avatar-loading" id="avatarLoading" role="status" aria-live="polite">
+            <div class="avatar-spinner" aria-hidden="true"></div>
+            <span class="sr-only">Loading avatar experience…</span>
+          </div>
           <div class="pupil-backdrop"></div>
           <div class="pupil left" id="pupilL"></div>
           <div class="pupil right" id="pupilR"></div>
@@ -2000,12 +2052,129 @@
   </div>
 
   <script>
+    const avatarImgEl = document.getElementById('avatarImg');
+    const avatarLoading = document.getElementById('avatarLoading');
+    const PUPIL_SPRITE_URL = 'assets/avatar_eye-pupil.png';
+    let backgroundLoadPromise = null;
+
+    let currentLocation = 'sf';
+    let isDayMode = true;
+
+    function waitForImageElement(img) {
+      if (!img) return Promise.resolve();
+      if (img.complete && img.naturalWidth > 0) {
+        return Promise.resolve();
+      }
+
+      return new Promise((resolve, reject) => {
+        const cleanup = () => {
+          img.removeEventListener('load', onLoad);
+          img.removeEventListener('error', onError);
+        };
+
+        const onLoad = () => {
+          cleanup();
+          resolve();
+        };
+
+        const onError = (event) => {
+          cleanup();
+          reject(event);
+        };
+
+        img.addEventListener('load', onLoad, { once: true });
+        img.addEventListener('error', onError, { once: true });
+      });
+    }
+
+    function preloadImage(url) {
+      if (!url) return Promise.resolve();
+
+      return new Promise((resolve, reject) => {
+        const image = new Image();
+        image.decoding = 'async';
+
+        const cleanup = () => {
+          image.onload = null;
+          image.onerror = null;
+        };
+
+        image.onload = () => {
+          cleanup();
+          resolve(url);
+        };
+
+        image.onerror = (event) => {
+          cleanup();
+          reject(event);
+        };
+
+        image.src = url;
+
+        if (image.complete && image.naturalWidth > 0) {
+          cleanup();
+          resolve(url);
+        }
+      });
+    }
+
+    function withTimeout(promise, ms = 8000) {
+      return new Promise((resolve) => {
+        const timeoutId = setTimeout(() => {
+          resolve('timeout');
+        }, ms);
+
+        promise
+          .then((value) => {
+            clearTimeout(timeoutId);
+            resolve(value);
+          })
+          .catch((error) => {
+            clearTimeout(timeoutId);
+            console.warn('Avatar assets failed to load in time:', error);
+            resolve();
+          });
+      });
+    }
+
+    function ensureBackgroundPreload(url) {
+      if (!url) return Promise.resolve();
+
+      backgroundLoadPromise = preloadImage(url).catch((error) => {
+        console.warn('Background failed to preload:', error);
+        return undefined;
+      });
+
+      return backgroundLoadPromise;
+    }
+
+    function setupAvatarLoader() {
+      if (!avatarLoading) return;
+
+      const tasks = [
+        waitForImageElement(avatarImgEl),
+        preloadImage(PUPIL_SPRITE_URL)
+      ];
+
+      const currentBackgroundUrl = getCurrentBackgroundUrl();
+      if (backgroundLoadPromise) {
+        tasks.push(backgroundLoadPromise);
+      } else if (currentBackgroundUrl) {
+        tasks.push(ensureBackgroundPreload(currentBackgroundUrl));
+      }
+
+      withTimeout(Promise.all(tasks), 8000).then(() => {
+        avatarLoading.classList.add('is-hidden');
+        avatarLoading.setAttribute('aria-hidden', 'true');
+      });
+    }
+
     // Eye-tracking logic with rAF throttling and clamped movement within a circle.
     (function () {
       const stage = document.getElementById('stage');
       const left = document.getElementById('pupilL');
       const right = document.getElementById('pupilR');
-      const avatarImg = document.getElementById('avatarImg');
+      const avatarImg = avatarImgEl;
 
       // Respect: reduced motion and non-fine pointers (phones/tablets)
       const motionOK = !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -2082,8 +2251,6 @@
     })();
 
     // Location and Theme Management
-    let currentLocation = 'sf';
-    let isDayMode = true;
 
     // Background image mapping
     const backgrounds = {
@@ -2100,6 +2267,11 @@
         night: 'assets/bliss-background-night.png'
       }
     };
+
+    function getCurrentBackgroundUrl(location = currentLocation, mode = isDayMode ? 'day' : 'night') {
+      const locationBackgrounds = backgrounds[location];
+      return locationBackgrounds ? locationBackgrounds[mode] : undefined;
+    }
 
     let backgroundTransitionToken = 0;
     const pendingTimeouts = new Set();
@@ -2130,20 +2302,29 @@
       const transitionToken = backgroundTransitionToken;
 
       const facetimeContent = document.querySelector('.facetime-content');
-      const mode = isDayMode ? 'day' : 'night';
-      const bgUrl = backgrounds[currentLocation][mode];
+      const bgUrl = getCurrentBackgroundUrl();
+      const backgroundPromise = ensureBackgroundPreload(bgUrl);
+
+      const applyBackground = () => {
+        if (!facetimeContent || transitionToken !== backgroundTransitionToken) return;
+
+        if (bgUrl) {
+          facetimeContent.style.setProperty('--bg-image', `url('${bgUrl}')`);
+        } else {
+          facetimeContent.style.removeProperty('--bg-image');
+        }
+      };
 
       // Check if user prefers reduced motion
       const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
       if (prefersReducedMotion || animationType === 'none') {
-        if (!facetimeContent) return;
-        facetimeContent.style.setProperty('--bg-image', `url('${bgUrl}')`);
-        return;
+        backgroundPromise.then(applyBackground);
+        return backgroundPromise;
       }
 
       if (animationType === 'iris') {
-        if (!facetimeContent) return;
+        if (!facetimeContent) return backgroundPromise;
         // Camera iris transition: close → swap → open
         facetimeContent.classList.remove('fade-in', 'fade-out');
 
@@ -2151,44 +2332,50 @@
         facetimeContent.classList.add('iris-close');
 
         scheduleStep(() => {
-          // Stage 2: Swap background at the closed moment
-          facetimeContent.style.setProperty('--bg-image', `url('${bgUrl}')`);
-          facetimeContent.classList.remove('iris-close');
+          backgroundPromise.then(() => {
+            if (transitionToken !== backgroundTransitionToken) return;
+            applyBackground();
+            facetimeContent.classList.remove('iris-close');
 
-          // Stage 3: Open the iris
-          facetimeContent.classList.add('iris-open');
+            // Stage 3: Open the iris
+            facetimeContent.classList.add('iris-open');
 
-          // Clean up after opening animation completes
-          scheduleStep(() => {
-            facetimeContent.classList.remove('iris-open');
-          }, 300, transitionToken);
+            // Clean up after opening animation completes
+            scheduleStep(() => {
+              facetimeContent.classList.remove('iris-open');
+            }, 300, transitionToken);
+          });
         }, 300, transitionToken);
-        return;
+        return backgroundPromise;
       }
 
       if (animationType === 'fade') {
-        if (!facetimeContent) return;
+        if (!facetimeContent) return backgroundPromise;
         facetimeContent.classList.remove('iris-close', 'iris-open', 'fade-in');
         facetimeContent.classList.add('fade-out');
 
         scheduleStep(() => {
-          facetimeContent.style.setProperty('--bg-image', `url('${bgUrl}')`);
-          facetimeContent.classList.remove('fade-out');
-          facetimeContent.classList.add('fade-in');
+          backgroundPromise.then(() => {
+            if (transitionToken !== backgroundTransitionToken) return;
+            applyBackground();
+            facetimeContent.classList.remove('fade-out');
+            facetimeContent.classList.add('fade-in');
 
-          scheduleStep(() => {
-            facetimeContent.classList.remove('fade-in');
-          }, 200, transitionToken);
+            scheduleStep(() => {
+              facetimeContent.classList.remove('fade-in');
+            }, 200, transitionToken);
+          });
         }, 200, transitionToken);
-        return;
+        return backgroundPromise;
       }
 
-      if (!facetimeContent) return;
-      facetimeContent.style.setProperty('--bg-image', `url('${bgUrl}')`);
+      backgroundPromise.then(applyBackground);
+      return backgroundPromise;
     }
 
     // Initialize background on page load
     updateBackground();
+    setupAvatarLoader();
 
     // Location switcher
     function switchLocation(location) {


### PR DESCRIPTION
## Summary
- add an overlay loader inside the FaceTime avatar stage with spinner and screen reader text
- style the loader, spinner animation, and sr-only helper to cover the stage while assets download
- preload avatar, pupil, and background imagery with new helpers so the overlay dismisses only after assets finish loading or timeout

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e35acf81c0832e88084818a3d1f437