### PR TITLE
Update greeting theme toggling logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -2304,7 +2304,9 @@
         ? `hello ${displayLabel}!`
         : `gn, ${displayLabel} :)`;
 
-      speechBubble.classList.toggle('speech-bubble--night', !isDayMode);
+      const targetNightMode = !isDayMode;
+      const isNightModeApplied = speechBubble.classList.contains('speech-bubble--night');
+      const shouldToggleTheme = isNightModeApplied !== targetNightMode;
 
       if (activeSpeechBubbleAnimationCleanup) {
         activeSpeechBubbleAnimationCleanup();
@@ -2321,6 +2323,9 @@
       const shouldAnimate = animate && canAnimateGreeting && messageChanged;
 
       if (!shouldAnimate) {
+        if (shouldToggleTheme) {
+          speechBubble.classList.toggle('speech-bubble--night', targetNightMode);
+        }
         if (messageChanged) {
           speechBubble.textContent = message;
         }
@@ -2346,6 +2351,9 @@
 
         speechBubble.removeEventListener('animationend', exitHandler);
         speechBubble.classList.remove('speech-bubble--exiting');
+        if (shouldToggleTheme) {
+          speechBubble.classList.toggle('speech-bubble--night', targetNightMode);
+        }
         speechBubble.textContent = message;
         speechBubble.classList.add('speech-bubble--entering');
 


### PR DESCRIPTION
## Summary
- cache the target night mode state when preparing the greeting
- update the non-animated branch to only toggle the night class when necessary
- adjust the animated transition to switch themes between exit and enter animations

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e364b5553c832eb2e052a9f45d69b0