### PR TITLE
Wire apple work dock icon to finder project grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -992,9 +992,9 @@
       display: none;
       position: absolute;
       width: 550px;
-      top: 40%;
+      top: 22%;
       left: 50%;
-      transform: translateX(-50%);
+      transform: translate(-50%, 0);
       z-index: 900;
       transition: box-shadow 0.2s ease;
     }
@@ -1004,12 +1004,24 @@
       left: 75%;
     }
 
+    #workWindow {
+      left: 30%;
+      top: 18%;
+      width: 500px;
+    }
+
+    .apple-project-window {
+      left: 70%;
+      top: 18%;
+      width: 520px;
+    }
+
     .project-window.active {
       display: block;
     }
 
     .project-window:hover {
-      transform: translateX(-50%) translateY(-2px);
+      transform: translate(-50%, -2px);
     }
 
     .project-actions {
@@ -1120,6 +1132,15 @@
       overflow: hidden;
       box-shadow: 0 2px 8px rgba(74, 14, 61, 0.15);
       transition: all 0.2s ease;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 20px;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+      background: var(--icon-bg, linear-gradient(135deg, #4b6cb7, #182848));
+      color: var(--icon-color, #ffffff);
+      text-transform: uppercase;
     }
 
     .project-grid-item:hover .project-grid-icon {
@@ -1138,7 +1159,7 @@
       color: var(--text-dark);
       text-align: center;
       line-height: 1.3;
-      max-width: 80px;
+      max-width: 120px;
     }
 
     /* --- Apple Project Windows --- */
@@ -1673,29 +1694,6 @@
       </div>
     </div>
 
-    <!-- Apple Work Placeholder Window -->
-    <div class="window project-window" id="appleWorkPlaceholderWindow">
-      <div class="window-titlebar">
-        <div class="window-controls">
-          <div class="window-button close" onclick="closeProjectWindow('appleWorkPlaceholderWindow')"></div>
-          <div class="window-button minimize"></div>
-          <div class="window-button maximize"></div>
-        </div>
-        <div class="window-title">apple-work</div>
-        <div style="width: 54px;"></div>
-      </div>
-      <div class="window-content">
-        <div style="text-align: center; padding: 40px 20px;">
-          <p style="font-size: 18px; font-weight: 600; color: var(--text-dark); margin-bottom: 8px;">
-            🚧 Under Construction 🚧
-          </p>
-          <p style="font-size: 13px; color: var(--text-muted);">
-            Check back soon!
-          </p>
-        </div>
-      </div>
-    </div>
-
     <!-- Work Window (Finder-style project grid) -->
     <div class="window project-window" id="workWindow">
       <div class="window-titlebar">
@@ -1708,43 +1706,7 @@
         <div style="width: 54px;"></div>
       </div>
       <div class="window-content">
-        <div class="project-grid">
-          <div class="project-grid-item" onclick="openAppleProject('researchAppWindow')">
-            <div class="project-grid-icon">
-              <!-- TODO: Replace with Apple Research app icon -->
-              <img src="assets/icon-os.png" alt="Apple Research App" />
-            </div>
-            <div class="project-grid-label">Apple Research App</div>
-          </div>
-          <div class="project-grid-item" onclick="openAppleProject('smartStackWindow')">
-            <div class="project-grid-icon">
-              <!-- TODO: Replace with Apple Watch or watchOS icon -->
-              <img src="assets/icon-os.png" alt="Smart Stack" />
-            </div>
-            <div class="project-grid-label">Smart Stack Workout Suggestions</div>
-          </div>
-          <div class="project-grid-item" onclick="openAppleProject('journalAppWindow')">
-            <div class="project-grid-icon">
-              <!-- TODO: Replace with Journal app icon -->
-              <img src="assets/icon-os.png" alt="Journal App" />
-            </div>
-            <div class="project-grid-label">Journal App</div>
-          </div>
-          <div class="project-grid-item" onclick="openAppleProject('airpodsHearingWindow')">
-            <div class="project-grid-icon">
-              <!-- TODO: Replace with AirPods or Health icon -->
-              <img src="assets/icon-os.png" alt="AirPods Hearing Aid" />
-            </div>
-            <div class="project-grid-label">AirPods Hearing Aid</div>
-          </div>
-          <div class="project-grid-item" onclick="openAppleProject('fitnessIphoneWindow')">
-            <div class="project-grid-icon">
-              <!-- TODO: Replace with Fitness app icon -->
-              <img src="assets/icon-os.png" alt="Fitness on iPhone" />
-            </div>
-            <div class="project-grid-label">Fitness on iPhone</div>
-          </div>
-        </div>
+        <div class="project-grid" id="appleProjectGrid"></div>
       </div>
     </div>
 
@@ -2038,7 +2000,7 @@
         <div class="dock-divider"></div>
 
         <!-- Work/Apple Projects Icon -->
-        <div class="dock-icon" onclick="openProjectWindow('appleWorkPlaceholderWindow')">
+        <div class="dock-icon" onclick="openProjectWindow('workWindow')">
           <img src="assets/icon-apple.png" alt="Work Projects" />
           <div class="dock-tooltip">apple-work</div>
         </div>
@@ -2067,6 +2029,41 @@
     const avatarLoading = document.getElementById('avatarLoading');
     const PUPIL_SPRITE_URL = 'assets/avatar_eye-pupil.png';
     let backgroundLoadPromise = null;
+    const APPLE_PROJECTS = [
+      {
+        id: 'researchAppWindow',
+        title: 'Apple Research App',
+        iconText: 'RA',
+        iconBackground: 'linear-gradient(135deg, #5a7bff, #9f63ff)'
+      },
+      {
+        id: 'smartStackWindow',
+        title: 'Smart Stack Workout Suggestions',
+        iconText: 'SS',
+        iconBackground: 'linear-gradient(135deg, #1ec8a5, #43d67a)'
+      },
+      {
+        id: 'journalAppWindow',
+        title: 'Journal App (iOS 17)',
+        iconText: 'JR',
+        iconBackground: 'linear-gradient(135deg, #ffd66b, #ff9f1c)',
+        iconColor: '#1b1b1f'
+      },
+      {
+        id: 'airpodsHearingWindow',
+        title: 'AirPods Hearing Aid Feature',
+        iconText: 'AP',
+        iconBackground: 'linear-gradient(135deg, #42a5f5, #4789ff)'
+      },
+      {
+        id: 'fitnessIphoneWindow',
+        title: 'Fitness on iPhone (Without Apple Watch)',
+        iconText: 'FIT',
+        iconBackground: 'linear-gradient(135deg, #ff5f6d, #ffc371)',
+        iconColor: '#1b1b1f'
+      }
+    ];
+    let projectWindowZIndex = 1000;
 
     function waitForImageElement(img) {
       if (!img) return Promise.resolve();
@@ -2593,34 +2590,34 @@
     })();
 
     // Dock project window interactions
-    function openProjectWindow(windowId) {
+    function openProjectWindow(windowId, options = {}) {
       const projectWindow = document.getElementById(windowId);
-      if (projectWindow) {
-        // Close any other open project windows
-        document.querySelectorAll('.project-window').forEach(w => {
+      if (!projectWindow) {
+        return;
+      }
+
+      const preserveIds = new Set(options.preserve || []);
+      preserveIds.add(windowId);
+
+      document.querySelectorAll('.project-window.active').forEach(w => {
+        if (!preserveIds.has(w.id)) {
           w.classList.remove('active');
-        });
-
-        // Open the selected window
-        projectWindow.classList.add('active');
-
-        // Bring to front
-        let zIndexCounter = 1000;
-        projectWindow.style.zIndex = zIndexCounter++;
-
-        // On small screens, ensure the window is visible to the user
-        if (window.matchMedia('(max-width: 768px)').matches) {
-          // Wait for the window to render before measuring
-          requestAnimationFrame(() => {
-            const rect = projectWindow.getBoundingClientRect();
-            const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
-            const fullyVisible = rect.top >= 0 && rect.bottom <= viewportHeight;
-
-            if (!fullyVisible) {
-              projectWindow.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            }
-          });
         }
+      });
+
+      projectWindow.classList.add('active');
+      projectWindow.style.zIndex = ++projectWindowZIndex;
+
+      if (window.matchMedia('(max-width: 768px)').matches) {
+        requestAnimationFrame(() => {
+          const rect = projectWindow.getBoundingClientRect();
+          const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+          const fullyVisible = rect.top >= 0 && rect.bottom <= viewportHeight;
+
+          if (!fullyVisible) {
+            projectWindow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          }
+        });
       }
     }
 
@@ -2633,28 +2630,54 @@
 
     // Apple project window interactions
     function openAppleProject(projectWindowId) {
-      // Close the work window
-      const workWindow = document.getElementById('workWindow');
-      if (workWindow) {
-        workWindow.classList.remove('active');
+      openProjectWindow(projectWindowId, { preserve: ['workWindow'] });
+    }
+
+    function renderAppleProjectGrid() {
+      const grid = document.getElementById('appleProjectGrid');
+      if (!grid) {
+        return;
       }
 
-      // Open the selected Apple project window
-      const projectWindow = document.getElementById(projectWindowId);
-      if (projectWindow) {
-        // Close any other open Apple project windows
-        document.querySelectorAll('.apple-project-window').forEach(w => {
-          w.classList.remove('active');
+      grid.textContent = '';
+
+      APPLE_PROJECTS.forEach(project => {
+        const item = document.createElement('div');
+        item.className = 'project-grid-item';
+        item.setAttribute('role', 'button');
+        item.setAttribute('tabindex', '0');
+        item.setAttribute('aria-label', project.title);
+
+        const icon = document.createElement('div');
+        icon.className = 'project-grid-icon';
+        icon.textContent = project.iconText;
+        if (project.iconBackground) {
+          icon.style.setProperty('--icon-bg', project.iconBackground);
+        }
+        if (project.iconColor) {
+          icon.style.setProperty('--icon-color', project.iconColor);
+        }
+
+        const label = document.createElement('div');
+        label.className = 'project-grid-label';
+        label.textContent = project.title;
+
+        const open = () => openAppleProject(project.id);
+        item.addEventListener('click', open);
+        item.addEventListener('keydown', event => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            open();
+          }
         });
 
-        // Open the selected window
-        projectWindow.classList.add('active');
-
-        // Bring to front
-        let zIndexCounter = 1000;
-        projectWindow.style.zIndex = zIndexCounter++;
-      }
+        item.appendChild(icon);
+        item.appendChild(label);
+        grid.appendChild(item);
+      });
     }
+
+    renderAppleProjectGrid();
 
     // Make dock icons accessible for link elements
     document.querySelectorAll('.dock-icon').forEach(icon => {


### PR DESCRIPTION
## Summary
- remove the temporary apple work placeholder window and render the finder-style grid from a shared Apple project data set
- keep the finder grid active when opening Apple detail popups, updating window management logic and positioning so both remain visible
- replace placeholder icons with styled text-based tiles that match the existing project detail windows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e47e307ecc832ebd868af5a2bf65fe