### PR TITLE
Add reusable reference cards for project resources

### DIFF
--- a/assets/data/appleProjects.json
+++ b/assets/data/appleProjects.json
@@ -29,14 +29,52 @@
     "tech": ["Swift", "iOS", "watchOS", "HealthKit", "ResearchKit", "Privacy & Security"],
     "referencesHeading": "Reference Cards",
     "references": [
-      { "type": "Press Release", "source": "Apple Newsroom · Nov 2019", "quote": "The Research app makes it easier than ever for people to contribute to groundbreaking studies.", "link": "https://www.apple.com/newsroom/2019/11/apple-launches-new-research-app/" },
-      { "type": "Tweet", "source": "Tim Cook", "quote": "The new Research app is a game changer—empowering iPhone and Apple Watch users to securely contribute to discoveries.", "link": "https://twitter.com/tim_cook/status/1195011313538037761" },
-      { "type": "Article", "source": "CNBC", "quote": "Apple’s Research app offers an unprecedented scale for medical studies by leveraging everyday devices.", "link": "https://www.cnbc.com/2019/11/14/apple-research-app-launches-with-three-new-health-studies.html" }
+      {
+        "type": "Press Release",
+        "source": "Apple Newsroom",
+        "title": "Apple launches new Research app",
+        "excerpt": "The Research app makes it easier than ever for people to contribute to groundbreaking studies.",
+        "meta": "Nov 2019",
+        "link": "https://www.apple.com/newsroom/2019/11/apple-launches-new-research-app/",
+        "image": "assets/icon-apple.png"
+      },
+      {
+        "type": "Tweet",
+        "source": "@tim_cook",
+        "title": "Tim Cook",
+        "excerpt": "The new Research app is a game changer—empowering iPhone and Apple Watch users to securely contribute to discoveries.",
+        "timestamp": "Nov 14, 2019",
+        "link": "https://twitter.com/tim_cook/status/1195011313538037761",
+        "avatar": "assets/reference-avatars/tim-cook.svg"
+      },
+      {
+        "type": "Article",
+        "source": "CNBC",
+        "title": "Apple’s Research app offers an unprecedented scale for medical studies",
+        "excerpt": "Apple’s Research app offers an unprecedented scale for medical studies by leveraging everyday devices.",
+        "meta": "Feature analysis",
+        "link": "https://www.cnbc.com/2019/11/14/apple-research-app-launches-with-three-new-health-studies.html",
+        "image": "assets/icon-file.png"
+      }
     ],
     "linksHeading": "Resources",
     "links": [
-      { "label": "Apple Newsroom", "url": "https://www.apple.com/newsroom/2019/11/apple-launches-new-research-app/" },
-      { "label": "App Store", "url": "https://apps.apple.com/us/app/apple-research/id1469938240" }
+      {
+        "type": "Press Release",
+        "source": "Apple Newsroom",
+        "title": "Research app overview",
+        "excerpt": "Official press release detailing the launch partners and study design of the Apple Research app.",
+        "link": "https://www.apple.com/newsroom/2019/11/apple-launches-new-research-app/",
+        "image": "assets/icon-apple.png"
+      },
+      {
+        "type": "App Store",
+        "source": "App Store",
+        "title": "Download Apple Research",
+        "excerpt": "Explore screenshots, feature highlights, and device requirements for the Apple Research app.",
+        "link": "https://apps.apple.com/us/app/apple-research/id1469938240",
+        "image": "assets/icon-apple.png"
+      }
     ]
   },
   {
@@ -69,14 +107,52 @@
     "tech": ["Swift", "watchOS", "WidgetKit", "On-device ML", "CoreMotion", "HealthKit"],
     "referencesHeading": "References",
     "references": [
-      { "type": "Press Release", "source": "Apple Newsroom · Jun 2023", "quote": "watchOS 10 introduces Smart Stack, delivering relevant widgets just when users need them.", "link": "https://www.apple.com/newsroom/2023/06/apple-watch-gets-its-biggest-update-since-its-introduction/" },
-      { "type": "WWDC Session", "source": "Design widgets for watchOS", "quote": "Discover how Smart Stack surfaces timely widgets to help people take action in the moment.", "link": "https://developer.apple.com/videos/play/wwdc2023/10054/" },
-      { "type": "Article", "source": "The Verge", "quote": "Smart Stack’s workout cards feel like having a coach tap you on the wrist at just the right time.", "link": "https://www.theverge.com/2023/9/12/23870853/apple-watchos-10-smart-stack-widgets" }
+      {
+        "type": "Press Release",
+        "source": "Apple Newsroom",
+        "title": "watchOS 10 introduces Smart Stack",
+        "excerpt": "watchOS 10 introduces Smart Stack, delivering relevant widgets just when users need them.",
+        "meta": "Jun 2023",
+        "link": "https://www.apple.com/newsroom/2023/06/apple-watch-gets-its-biggest-update-since-its-introduction/",
+        "image": "assets/icon-apple.png"
+      },
+      {
+        "type": "WWDC Session",
+        "source": "WWDC23",
+        "title": "Design widgets for watchOS",
+        "excerpt": "Discover how Smart Stack surfaces timely widgets to help people take action in the moment.",
+        "meta": "Session 10054",
+        "link": "https://developer.apple.com/videos/play/wwdc2023/10054/",
+        "image": "assets/icon-file.png"
+      },
+      {
+        "type": "Article",
+        "source": "The Verge",
+        "title": "Smart Stack’s workout cards feel like a coach on your wrist",
+        "excerpt": "Smart Stack’s workout cards feel like having a coach tap you on the wrist at just the right time.",
+        "meta": "Launch coverage",
+        "link": "https://www.theverge.com/2023/9/12/23870853/apple-watchos-10-smart-stack-widgets",
+        "image": "assets/icon-file.png"
+      }
     ],
     "linksHeading": "Resources",
     "links": [
-      { "label": "watchOS 10 Overview", "url": "https://www.apple.com/watchos/watchos-10/" },
-      { "label": "WWDC Session", "url": "https://developer.apple.com/videos/play/wwdc2023/10054/" }
+      {
+        "type": "Overview",
+        "source": "Apple",
+        "title": "watchOS 10 product page",
+        "excerpt": "Learn how the redesigned Smart Stack keeps glanceable information within a swipe on Apple Watch.",
+        "link": "https://www.apple.com/watchos/watchos-10/",
+        "image": "assets/icon-apple.png"
+      },
+      {
+        "type": "Developer",
+        "source": "Apple Developer",
+        "title": "WWDC session: Design widgets for watchOS",
+        "excerpt": "Session video that breaks down composing glanceable Smart Stack cards with WidgetKit.",
+        "link": "https://developer.apple.com/videos/play/wwdc2023/10054/",
+        "image": "assets/icon-file.png"
+      }
     ]
   },
   {
@@ -110,14 +186,51 @@
     "tech": ["Swift", "iOS", "Machine Learning", "Privacy & Encryption", "Face ID / Touch ID", "Core Data"],
     "referencesHeading": "Coverage",
     "references": [
-      { "type": "Press Release", "source": "Apple Newsroom · Dec 2023", "quote": "Journal helps iPhone users reflect on everyday moments and preserve their memories.", "link": "https://www.apple.com/newsroom/2023/12/apple-launches-journal-app-a-new-app-for-reflecting-on-everyday-moments/" },
-      { "type": "Article", "source": "MacRumors", "quote": "Apple’s Journal app arrives with thoughtful design and deep integrations across the iPhone experience.", "link": "https://www.macrumors.com/2023/12/11/apple-releases-journal-app/" },
-      { "type": "Community Quote", "source": "Day One Founder", "quote": "Journal ushers in a new chapter for the practice of digital journaling.", "link": "https://dayoneapp.com/blog/apple-journal-app/" }
+      {
+        "type": "Press Release",
+        "source": "Apple Newsroom",
+        "title": "Journal helps iPhone users reflect on everyday moments",
+        "excerpt": "Journal helps iPhone users reflect on everyday moments and preserve their memories.",
+        "meta": "Dec 2023",
+        "link": "https://www.apple.com/newsroom/2023/12/apple-launches-journal-app-a-new-app-for-reflecting-on-everyday-moments/",
+        "image": "assets/icon-apple.png"
+      },
+      {
+        "type": "Article",
+        "source": "MacRumors",
+        "title": "Apple’s Journal app arrives with thoughtful design",
+        "excerpt": "Apple’s Journal app arrives with thoughtful design and deep integrations across the iPhone experience.",
+        "meta": "App launch coverage",
+        "link": "https://www.macrumors.com/2023/12/11/apple-releases-journal-app/",
+        "image": "assets/icon-file.png"
+      },
+      {
+        "type": "Community Quote",
+        "source": "Day One Founder",
+        "title": "A new chapter for digital journaling",
+        "excerpt": "Journal ushers in a new chapter for the practice of digital journaling.",
+        "link": "https://dayoneapp.com/blog/apple-journal-app/",
+        "image": "assets/icon-file.png"
+      }
     ],
     "linksHeading": "Resources",
     "links": [
-      { "label": "Apple Newsroom", "url": "https://www.apple.com/newsroom/2023/12/apple-launches-journal-app-a-new-app-for-reflecting-on-everyday-moments/" },
-      { "label": "App Store", "url": "https://apps.apple.com/us/app/journal/id6446009975" }
+      {
+        "type": "Press Release",
+        "source": "Apple Newsroom",
+        "title": "Journal app announcement",
+        "excerpt": "Official newsroom story detailing Journal’s design pillars and privacy protections.",
+        "link": "https://www.apple.com/newsroom/2023/12/apple-launches-journal-app-a-new-app-for-reflecting-on-everyday-moments/",
+        "image": "assets/icon-apple.png"
+      },
+      {
+        "type": "App Store",
+        "source": "App Store",
+        "title": "Download Journal on the App Store",
+        "excerpt": "Review feature highlights, ratings, and platform requirements for Journal.",
+        "link": "https://apps.apple.com/us/app/journal/id6446009975",
+        "image": "assets/icon-apple.png"
+      }
     ]
   },
   {
@@ -150,14 +263,52 @@
     "tech": ["Swift", "iOS 18", "AirPods Pro 2", "Audio Processing", "FDA-Regulated Software", "Clinical Validation"],
     "referencesHeading": "References",
     "references": [
-      { "type": "Press Release", "source": "Apple Newsroom · Sep 2024", "quote": "Apple introduces groundbreaking health features, including turning AirPods Pro into FDA-authorized hearing aids.", "link": "https://www.apple.com/newsroom/2024/09/apple-introduces-groundbreaking-health-features/" },
-      { "type": "Press Release", "source": "U.S. FDA", "quote": "FDA authorizes the first over-the-counter hearing aid software device.", "link": "https://www.fda.gov/news-events/press-announcements/fda-authorizes-first-over-counter-hearing-aid-software" },
-      { "type": "Article", "source": "The Verge", "quote": "AirPods Pro are about to double as hearing aids you can set up from your couch.", "link": "https://www.theverge.com/2024/9/10/23866095/apple-airpods-pro-hearing-test-fda-approval" }
+      {
+        "type": "Press Release",
+        "source": "Apple Newsroom",
+        "title": "Apple introduces groundbreaking health features",
+        "excerpt": "Apple introduces groundbreaking health features, including turning AirPods Pro into FDA-authorized hearing aids.",
+        "meta": "Sep 2024",
+        "link": "https://www.apple.com/newsroom/2024/09/apple-introduces-groundbreaking-health-features/",
+        "image": "assets/icon-apple.png"
+      },
+      {
+        "type": "Press Release",
+        "source": "U.S. FDA",
+        "title": "FDA authorizes the first over-the-counter hearing aid software device",
+        "excerpt": "FDA authorizes the first over-the-counter hearing aid software device.",
+        "meta": "Regulatory announcement",
+        "link": "https://www.fda.gov/news-events/press-announcements/fda-authorizes-first-over-counter-hearing-aid-software",
+        "image": "assets/icon-file.png"
+      },
+      {
+        "type": "Article",
+        "source": "The Verge",
+        "title": "AirPods Pro are about to double as hearing aids",
+        "excerpt": "AirPods Pro are about to double as hearing aids you can set up from your couch.",
+        "meta": "Product coverage",
+        "link": "https://www.theverge.com/2024/9/10/23866095/apple-airpods-pro-hearing-test-fda-approval",
+        "image": "assets/icon-file.png"
+      }
     ],
     "linksHeading": "Resources",
     "links": [
-      { "label": "Apple Newsroom", "url": "https://www.apple.com/newsroom/2024/09/apple-introduces-groundbreaking-health-features/" },
-      { "label": "FDA Announcement", "url": "https://www.fda.gov/news-events/press-announcements/fda-authorizes-first-over-counter-hearing-aid-software" }
+      {
+        "type": "Press Release",
+        "source": "Apple Newsroom",
+        "title": "AirPods hearing health hub",
+        "excerpt": "Read the full announcement on hearing health features coming to AirPods Pro and iPhone.",
+        "link": "https://www.apple.com/newsroom/2024/09/apple-introduces-groundbreaking-health-features/",
+        "image": "assets/icon-apple.png"
+      },
+      {
+        "type": "Regulatory",
+        "source": "U.S. FDA",
+        "title": "FDA authorization release",
+        "excerpt": "Official FDA announcement detailing the authorization of Apple’s over-the-counter hearing aid software.",
+        "link": "https://www.fda.gov/news-events/press-announcements/fda-authorizes-first-over-counter-hearing-aid-software",
+        "image": "assets/icon-file.png"
+      }
     ]
   },
   {
@@ -190,14 +341,51 @@
     "tech": ["Swift", "iOS", "CoreMotion", "HealthKit", "Live Activities", "External Sensor Integration"],
     "referencesHeading": "References",
     "references": [
-      { "type": "Press Release", "source": "Apple Newsroom · Sep 2022", "quote": "Later this fall, all iPhone customers will be able to subscribe to Apple Fitness+.", "link": "https://www.apple.com/newsroom/2022/09/apple-fitness-plus-available-to-all-iphone-users/" },
-      { "type": "Support Doc", "source": "Apple Support", "quote": "You can track your daily activity on iPhone even if you don’t have an Apple Watch.", "link": "https://support.apple.com/guide/iphone/ipha5dddb411/ios" },
-      { "type": "Article", "source": "TechCrunch", "quote": "Apple is sherlocking basic fitness tracking by baking it directly into every iPhone.", "link": "https://techcrunch.com/2022/09/07/apple-fitness-plus-iphone/" }
+      {
+        "type": "Press Release",
+        "source": "Apple Newsroom",
+        "title": "Apple Fitness+ available to all iPhone users",
+        "excerpt": "Later this fall, all iPhone customers will be able to subscribe to Apple Fitness+.",
+        "meta": "Sep 2022",
+        "link": "https://www.apple.com/newsroom/2022/09/apple-fitness-plus-available-to-all-iphone-users/",
+        "image": "assets/icon-apple.png"
+      },
+      {
+        "type": "Support Doc",
+        "source": "Apple Support",
+        "title": "Track activity with iPhone",
+        "excerpt": "You can track your daily activity on iPhone even if you don’t have an Apple Watch.",
+        "link": "https://support.apple.com/guide/iphone/ipha5dddb411/ios",
+        "image": "assets/icon-file.png"
+      },
+      {
+        "type": "Article",
+        "source": "TechCrunch",
+        "title": "Apple brings Fitness tracking to every iPhone",
+        "excerpt": "Apple is sherlocking basic fitness tracking by baking it directly into every iPhone.",
+        "meta": "Launch coverage",
+        "link": "https://techcrunch.com/2022/09/07/apple-fitness-plus-iphone/",
+        "image": "assets/icon-file.png"
+      }
     ],
     "linksHeading": "Resources",
     "links": [
-      { "label": "Fitness+", "url": "https://www.apple.com/apple-fitness-plus/" },
-      { "label": "Support Guide", "url": "https://support.apple.com/guide/iphone/ipha5dddb411/ios" }
+      {
+        "type": "Product",
+        "source": "Apple",
+        "title": "Explore Apple Fitness+",
+        "excerpt": "Preview studio classes, trainers, and subscription benefits available on iPhone.",
+        "link": "https://www.apple.com/apple-fitness-plus/",
+        "image": "assets/icon-apple.png"
+      },
+      {
+        "type": "Support",
+        "source": "Apple Support",
+        "title": "iPhone activity support guide",
+        "excerpt": "Step-by-step instructions for closing Move rings using just your iPhone sensors.",
+        "link": "https://support.apple.com/guide/iphone/ipha5dddb411/ios",
+        "image": "assets/icon-file.png"
+      }
     ]
   }
 ]

--- a/assets/reference-avatars/tim-cook.svg
+++ b/assets/reference-avatars/tim-cook.svg
@@ -1,0 +1,10 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Tim Cook avatar">
+  <defs>
+    <linearGradient id="tcGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8bc6ff" />
+      <stop offset="100%" stop-color="#2b6ecb" />
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="32" fill="url(#tcGradient)" />
+  <text x="32" y="38" font-family="'SF Pro Display', 'Helvetica Neue', Arial, sans-serif" font-size="26" font-weight="600" text-anchor="middle" fill="#ffffff">TC</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1312,56 +1312,148 @@
       margin: 0;
     }
 
-    .apple-project-reference-gallery {
+    .apple-project-reference-gallery,
+    .apple-project-resource-list {
       display: grid;
       gap: 12px;
     }
 
-    .reference-card {
-      background: rgba(255, 255, 255, 0.85);
-      border: 1px solid rgba(74, 14, 61, 0.1);
-      border-radius: 12px;
-      padding: 14px 16px;
-      box-shadow: 0 6px 18px rgba(74, 14, 61, 0.1);
+    .apple-project-resource-list {
+      margin-top: 12px;
     }
 
-    .reference-type {
+    .reference-card {
+      position: relative;
+      border-radius: 16px;
+      background: rgba(255, 255, 255, 0.92);
+      border: 1px solid rgba(74, 14, 61, 0.08);
+      box-shadow: 0 8px 24px rgba(74, 14, 61, 0.12);
+    }
+
+    .reference-card__link {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 16px;
+      align-items: start;
+      padding: 16px 18px;
+      color: inherit;
+      text-decoration: none;
+      border-radius: 16px;
+      position: relative;
+      z-index: 1;
+    }
+
+    .reference-card__link--no-media {
+      grid-template-columns: 1fr;
+    }
+
+    .reference-card__link:focus-visible {
+      outline: 2px solid rgba(181, 71, 128, 0.8);
+      outline-offset: 4px;
+    }
+
+    .reference-card__media {
+      width: 48px;
+      height: 48px;
+      border-radius: 12px;
+      overflow: hidden;
+      background: rgba(74, 14, 61, 0.08);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .reference-card__media img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    .reference-card__fallback {
+      font-size: 18px;
+      font-weight: 600;
+      color: var(--text-dark);
+    }
+
+    .reference-card__body {
+      display: grid;
+      gap: 6px;
+    }
+
+    .reference-card__type {
       font-size: 11px;
       text-transform: uppercase;
-      letter-spacing: 1px;
+      letter-spacing: 0.08em;
       color: var(--text-muted);
-      margin-bottom: 6px;
     }
 
-    .reference-quote {
+    .reference-card__title {
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--text-dark);
+      line-height: 1.4;
+    }
+
+    .reference-card__excerpt {
       font-size: 13px;
       line-height: 1.6;
       color: var(--text-dark);
-      font-style: italic;
-      margin: 0 0 12px;
+      margin: 0;
     }
 
-    .reference-source {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 8px;
+    .reference-card__excerpt--tweet {
+      font-style: normal;
     }
 
-    .reference-source span {
+    .reference-card__meta {
       font-size: 12px;
       color: var(--text-muted);
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      flex-wrap: wrap;
     }
 
-    .reference-source a {
-      font-size: 12px;
-      font-weight: 600;
+    .reference-card--tweet {
+      background: linear-gradient(135deg, rgba(56, 151, 240, 0.18), rgba(255, 255, 255, 0.95));
+      border-color: rgba(56, 151, 240, 0.25);
+    }
+
+    .reference-card--tweet .reference-card__type {
+      color: rgba(56, 151, 240, 0.9);
+    }
+
+    .reference-card--tweet .reference-card__media {
+      border-radius: 50%;
+      background: rgba(56, 151, 240, 0.18);
+    }
+
+    .reference-card__tweet-author {
+      display: flex;
+      gap: 8px;
+      align-items: baseline;
+      font-size: 13px;
       color: var(--text-dark);
-      text-decoration: none;
     }
 
-    .reference-source a:hover {
-      text-decoration: underline;
+    .reference-card__tweet-handle {
+      color: rgba(56, 151, 240, 0.9);
+      font-weight: 500;
+      font-size: 12px;
+    }
+
+    .reference-card--press .reference-card__media,
+    .reference-card--article .reference-card__media,
+    .reference-card--news .reference-card__media {
+      background: rgba(181, 71, 128, 0.1);
+    }
+
+    .reference-card--press .reference-card__type,
+    .reference-card--article .reference-card__type,
+    .reference-card--news .reference-card__type {
+      color: rgba(181, 71, 128, 0.85);
     }
 
     .project-description {
@@ -1393,10 +1485,9 @@
       box-shadow: 0 8px 20px rgba(74, 14, 61, 0.18);
     }
 
-    .resource-links {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
+    .reference-card__link:hover .reference-card__title,
+    .reference-card__link:focus-visible .reference-card__title {
+      text-decoration: underline;
     }
 
     /* --- Screenshot Gallery & Phone Mockups --- */
@@ -2274,6 +2365,186 @@
       return heading;
     }
 
+    const referenceTypeSlug = type => (type || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'resource';
+
+    function createReferenceMedia(entry) {
+      const mediaWrapper = document.createElement('div');
+      mediaWrapper.className = 'reference-card__media';
+
+      const hasAvatar = Boolean(entry && entry.avatar);
+      const mediaSrc = (entry && (entry.avatar || entry.image || entry.icon)) || null;
+      if (mediaSrc) {
+        const img = document.createElement('img');
+        img.src = mediaSrc;
+        const altSeed = (entry && (entry.mediaAlt || entry.source || entry.title || entry.label)) || 'Reference';
+        img.alt = hasAvatar ? `${altSeed} avatar` : `${altSeed} logo`;
+        img.loading = 'lazy';
+        mediaWrapper.appendChild(img);
+        return mediaWrapper;
+      }
+
+      const fallbackSeed = ((entry && (entry.badge || entry.source || entry.title || entry.label)) || '').trim();
+      if (!fallbackSeed) {
+        return null;
+      }
+
+      const fallback = document.createElement('div');
+      fallback.className = 'reference-card__fallback';
+      fallback.textContent = fallbackSeed.charAt(0).toUpperCase();
+      mediaWrapper.appendChild(fallback);
+      return mediaWrapper;
+    }
+
+    function createReferenceCard(entry) {
+      if (!entry || !entry.link) {
+        return null;
+      }
+
+      const normalizedType = (entry.type || '').toLowerCase();
+      const isTweet = normalizedType.includes('tweet');
+      const isPress = normalizedType.includes('press') || normalizedType.includes('news') || normalizedType.includes('article');
+
+      const article = document.createElement('article');
+      article.className = 'reference-card';
+      article.setAttribute('role', 'listitem');
+
+      const slug = referenceTypeSlug(entry.type);
+      if (slug) {
+        article.classList.add(`reference-card--${slug}`);
+      }
+
+      if (isTweet) {
+        article.classList.add('reference-card--tweet');
+      } else if (isPress) {
+        article.classList.add('reference-card--press');
+      } else {
+        article.classList.add('reference-card--resource');
+      }
+
+      const anchor = document.createElement('a');
+      anchor.href = entry.link;
+      anchor.target = '_blank';
+      anchor.rel = 'noopener noreferrer';
+      anchor.className = 'reference-card__link';
+
+      const ariaLabelParts = [];
+      if (entry.title) {
+        ariaLabelParts.push(entry.title);
+      } else if (entry.label) {
+        ariaLabelParts.push(entry.label);
+      }
+      if (entry.source) {
+        ariaLabelParts.push(`from ${entry.source}`);
+      }
+      const ariaLabel = ariaLabelParts.join(' ');
+      if (ariaLabel) {
+        anchor.setAttribute('aria-label', `Open ${ariaLabel}`);
+      } else {
+        anchor.setAttribute('aria-label', 'Open external resource');
+      }
+
+      const media = createReferenceMedia(entry);
+      if (media) {
+        anchor.appendChild(media);
+      } else {
+        anchor.classList.add('reference-card__link--no-media');
+      }
+
+      const body = document.createElement('div');
+      body.className = 'reference-card__body';
+
+      if (entry.type) {
+        const typeLabel = document.createElement('span');
+        typeLabel.className = 'reference-card__type';
+        typeLabel.textContent = entry.type;
+        body.appendChild(typeLabel);
+      }
+
+      if (isTweet) {
+        if (entry.title || entry.source) {
+          const authorRow = document.createElement('div');
+          authorRow.className = 'reference-card__tweet-author';
+
+          if (entry.title) {
+            const nameEl = document.createElement('span');
+            nameEl.className = 'reference-card__title';
+            nameEl.textContent = entry.title;
+            authorRow.appendChild(nameEl);
+          }
+
+          if (entry.source) {
+            const handleEl = document.createElement('span');
+            handleEl.className = 'reference-card__tweet-handle';
+            handleEl.textContent = entry.source;
+            authorRow.appendChild(handleEl);
+          }
+
+          body.appendChild(authorRow);
+        }
+
+        if (entry.excerpt || entry.quote) {
+          const tweetText = document.createElement('p');
+          tweetText.className = 'reference-card__excerpt reference-card__excerpt--tweet';
+          tweetText.textContent = entry.excerpt || entry.quote;
+          body.appendChild(tweetText);
+        }
+
+        const metaParts = [];
+        if (entry.timestamp) {
+          metaParts.push(entry.timestamp);
+        }
+        if (entry.meta) {
+          metaParts.push(entry.meta);
+        }
+        if (metaParts.length) {
+          const meta = document.createElement('div');
+          meta.className = 'reference-card__meta';
+          meta.textContent = metaParts.join(' · ');
+          body.appendChild(meta);
+        }
+      } else {
+        const titleText = entry.title || entry.label || '';
+        if (titleText) {
+          const titleEl = document.createElement('div');
+          titleEl.className = 'reference-card__title';
+          titleEl.textContent = titleText;
+          body.appendChild(titleEl);
+        }
+
+        if (entry.excerpt || entry.quote || entry.description) {
+          const excerptEl = document.createElement('p');
+          excerptEl.className = 'reference-card__excerpt';
+          excerptEl.textContent = entry.excerpt || entry.quote || entry.description;
+          body.appendChild(excerptEl);
+        }
+
+        const metaParts = [];
+        if (entry.source) {
+          metaParts.push(entry.source);
+        }
+        if (entry.meta) {
+          metaParts.push(entry.meta);
+        }
+        if (entry.timestamp && !metaParts.includes(entry.timestamp)) {
+          metaParts.push(entry.timestamp);
+        }
+        if (entry.host) {
+          metaParts.push(entry.host);
+        }
+
+        if (metaParts.length) {
+          const meta = document.createElement('div');
+          meta.className = 'reference-card__meta';
+          meta.textContent = metaParts.join(' · ');
+          body.appendChild(meta);
+        }
+      }
+
+      anchor.appendChild(body);
+      article.appendChild(anchor);
+      return article;
+    }
+
     function showAppleProjectsError() {
       const grid = document.getElementById('appleProjectGrid');
       const windowsContainer = document.getElementById('appleProjectWindowsContainer');
@@ -2492,50 +2763,21 @@
         referenceSection.appendChild(createSectionHeading(project.referencesHeading || 'References'));
         const cards = document.createElement('div');
         cards.className = 'apple-project-reference-gallery';
+        cards.setAttribute('role', 'list');
 
+        let hasReferenceCards = false;
         project.references.forEach(ref => {
-          const card = document.createElement('article');
-          card.className = 'reference-card';
-
-          if (ref.type) {
-            const type = document.createElement('div');
-            type.className = 'reference-type';
-            type.textContent = ref.type;
-            card.appendChild(type);
+          const card = createReferenceCard(ref);
+          if (card) {
+            cards.appendChild(card);
+            hasReferenceCards = true;
           }
-
-          if (ref.quote) {
-            const quote = document.createElement('p');
-            quote.className = 'reference-quote';
-            quote.textContent = ref.quote;
-            card.appendChild(quote);
-          }
-
-          if (ref.source || ref.link) {
-            const sourceRow = document.createElement('div');
-            sourceRow.className = 'reference-source';
-
-            const sourceText = document.createElement('span');
-            sourceText.textContent = ref.source || '';
-            sourceRow.appendChild(sourceText);
-
-            if (ref.link) {
-              const anchor = document.createElement('a');
-              anchor.href = ref.link;
-              anchor.target = '_blank';
-              anchor.rel = 'noopener noreferrer';
-              anchor.textContent = 'Open →';
-              sourceRow.appendChild(anchor);
-            }
-
-            card.appendChild(sourceRow);
-          }
-
-          cards.appendChild(card);
         });
 
-        referenceSection.appendChild(cards);
-        content.appendChild(referenceSection);
+        if (hasReferenceCards) {
+          referenceSection.appendChild(cards);
+          content.appendChild(referenceSection);
+        }
       }
 
       if (Array.isArray(project.links) && project.links.length) {
@@ -2543,21 +2785,26 @@
         resourcesSection.className = 'apple-project-section apple-project-resources';
         resourcesSection.appendChild(createSectionHeading(project.linksHeading || 'Resources'));
         const linksContainer = document.createElement('div');
-        linksContainer.className = 'resource-links';
+        linksContainer.className = 'apple-project-resource-list';
+        linksContainer.setAttribute('role', 'list');
 
+        let hasResourceCards = false;
         project.links.forEach(link => {
-          if (!link || !link.url) return;
-          const anchor = document.createElement('a');
-          anchor.href = link.url;
-          anchor.className = 'project-link';
-          anchor.target = '_blank';
-          anchor.rel = 'noopener noreferrer';
-          anchor.textContent = `${link.label || 'Open'} →`;
-          linksContainer.appendChild(anchor);
+          const card = createReferenceCard({
+            ...link,
+            link: link.url || link.link
+          });
+
+          if (card) {
+            linksContainer.appendChild(card);
+            hasResourceCards = true;
+          }
         });
 
-        resourcesSection.appendChild(linksContainer);
-        content.appendChild(resourcesSection);
+        if (hasResourceCards) {
+          resourcesSection.appendChild(linksContainer);
+          content.appendChild(resourcesSection);
+        }
       }
 
       windowEl.append(titlebar, content);


### PR DESCRIPTION
## Summary
- add a reusable ReferenceCard renderer and styling for project references and resources
- update the Apple projects dataset with rich metadata for tweets, press, and resources
- include a branded avatar for tweet content and ensure cards open in new tabs with accessible roles

## Testing
- python -m json.tool assets/data/appleProjects.json

------
https://chatgpt.com/codex/tasks/task_e_68e48ff6fe00832e9de2393c7f49f255