### PR TITLE
Preserve Finder window when opening Apple project details

### DIFF
--- a/index.html
+++ b/index.html
@@ -3394,9 +3394,12 @@
     // Dock project window interactions
     function openProjectWindow(windowId, options = {}) {
       const projectWindow = document.getElementById(windowId);
+      // options.preserveIds allows specific window IDs to keep their active state (e.g., Finder remaining open)
+      const preserveIds = options.preserveIds ?? [];
+      const preserveSet = new Set(Array.isArray(preserveIds) ? preserveIds : [preserveIds].filter(Boolean));
       if (projectWindow) {
         document.querySelectorAll('.project-window').forEach(w => {
-          if (w !== projectWindow) {
+          if (w !== projectWindow && !preserveSet.has(w.id)) {
             w.classList.remove('active');
           }
         });
@@ -3429,20 +3432,10 @@
     function openAppleProject(projectWindowId) {
       const workWindow = document.getElementById('workWindow');
       if (workWindow) {
-        workWindow.classList.remove('active');
+        workWindow.classList.add('active');
       }
 
-      const projectWindow = document.getElementById(projectWindowId);
-      if (projectWindow) {
-        document.querySelectorAll('.apple-project-window').forEach(w => {
-          if (w !== projectWindow) {
-            w.classList.remove('active');
-          }
-        });
-
-        projectWindow.classList.add('active');
-        bringWindowToFront(projectWindow);
-      }
+      openProjectWindow(projectWindowId, { preserveIds: ['workWindow'] });
     }
 
     renderAppleProjects();


### PR DESCRIPTION
## Summary
- allow openProjectWindow to preserve specific window IDs when activating another window
- ensure the Apple Finder window stays active while detail windows open by preserving it during openAppleProject

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4a4644800832ea7138e5d5c6938bf