### PR TITLE
Extend pushable styling to GitHub icon button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1042,21 +1042,15 @@
 
     .project-launch {
       position: relative;
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      padding: 9px 18px;
-      background: linear-gradient(135deg, #ffe3ef 0%, #f48fb1 45%, #f06292 100%);
+      display: inline-block;
+      padding: 0;
+      background: #6d1749;
       border-radius: 999px;
-      border-top: 1px solid rgba(255, 255, 255, 0.6);
-      border-bottom: 1px solid rgba(129, 27, 89, 0.35);
-      color: white;
+      border: none;
+      cursor: pointer;
       text-decoration: none;
-      font-size: 13px;
-      font-weight: 600;
-      letter-spacing: 0.3px;
-      transition: transform 0.2s ease, filter 0.2s ease;
-      z-index: 1;
+      color: inherit;
+      transition: transform 0.2s var(--micro-ease);
     }
 
     .project-launch::after {
@@ -1064,55 +1058,114 @@
       position: absolute;
       inset: 0;
       border-radius: inherit;
-      background: linear-gradient(180deg, rgba(162, 25, 95, 0.55), rgba(97, 13, 67, 0.65));
-      transform: translateY(6px);
-      transition: transform 0.2s ease, filter 0.2s ease;
-      z-index: -1;
+      background: linear-gradient(180deg, rgba(71, 8, 45, 0.95), rgba(122, 21, 74, 0.9));
+      transform: translateY(4px);
+      transition: transform 0.2s var(--micro-ease), filter 0.2s ease;
+      z-index: 0;
     }
 
-    .project-launch:hover {
-      transform: translateY(-2px);
+    .project-launch__front {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 10px 20px;
+      border-radius: inherit;
+      background: linear-gradient(135deg, #ffe3ef 0%, #f48fb1 45%, #f06292 100%);
+      color: white;
+      font-size: 13px;
+      font-weight: 600;
+      letter-spacing: 0.3px;
+      transform: translateY(-6px);
+      transition: transform 0.2s var(--micro-ease), filter 0.2s ease;
+      z-index: 1;
+    }
+
+    .project-launch:hover .project-launch__front {
       filter: brightness(1.08);
     }
 
-    .project-launch:hover::after {
-      transform: translateY(3px);
+    .project-launch:active .project-launch__front {
+      transform: translateY(-2px);
       filter: brightness(0.95);
     }
 
-    .project-launch:active {
-      transform: translateY(-2px);
-      filter: brightness(0.94) saturate(1.1);
+    .project-launch:hover::after {
+      filter: brightness(0.92);
     }
 
     .project-launch:active::after {
-      transform: translateY(1px);
+      transform: translateY(2px);
       filter: brightness(0.85);
     }
 
     .project-launch:focus-visible {
       outline: 3px solid rgba(255, 255, 255, 0.7);
-      outline-offset: 2px;
+      outline-offset: 3px;
     }
 
     .project-icon-link {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 38px;
-      height: 38px;
+      position: relative;
+      display: inline-block;
+      width: 42px;
+      height: 42px;
       border-radius: 50%;
-      border: 1px solid var(--pink-border);
-      background: var(--pink-light);
-      color: var(--text-dark);
+      padding: 0;
+      background: #6d1749;
+      border: none;
+      color: inherit;
       text-decoration: none;
-      transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+      cursor: pointer;
+      transition: transform 0.2s var(--micro-ease);
     }
 
-    .project-icon-link:hover {
-      transform: translateY(-1px);
-      border-color: rgba(74, 14, 61, 0.25);
-      box-shadow: 0 6px 16px rgba(74, 14, 61, 0.2);
+    .project-icon-link::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background: linear-gradient(180deg, rgba(71, 8, 45, 0.95), rgba(122, 21, 74, 0.9));
+      transform: translateY(4px);
+      transition: transform 0.2s var(--micro-ease), filter 0.2s ease;
+      z-index: 0;
+    }
+
+    .project-icon-link__front {
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      height: 100%;
+      border-radius: inherit;
+      background: linear-gradient(135deg, #ffe3ef 0%, #f48fb1 45%, #f06292 100%);
+      color: white;
+      transform: translateY(-6px);
+      transition: transform 0.2s var(--micro-ease), filter 0.2s ease;
+      z-index: 1;
+    }
+
+    .project-icon-link:hover .project-icon-link__front {
+      filter: brightness(1.08);
+    }
+
+    .project-icon-link:active .project-icon-link__front {
+      transform: translateY(-2px);
+      filter: brightness(0.95);
+    }
+
+    .project-icon-link:hover::after {
+      filter: brightness(0.92);
+    }
+
+    .project-icon-link:active::after {
+      transform: translateY(2px);
+      filter: brightness(0.85);
+    }
+
+    .project-icon-link:focus-visible {
+      outline: 3px solid rgba(255, 255, 255, 0.7);
+      outline-offset: 3px;
     }
 
     .sr-only {
@@ -2180,13 +2233,17 @@
         </p>
         <div class="project-actions">
           <a href="https://frankies-spelling-bee.vercel.app" class="project-launch" target="_blank">
-            <span>Launch</span>
-            <span aria-hidden="true">🚀</span>
+            <span class="project-launch__front">
+              <span>Launch</span>
+              <span aria-hidden="true">🚀</span>
+            </span>
           </a>
           <a href="https://github.com/rhea-s/spelling-bee/tree/main" class="project-icon-link" target="_blank" aria-label="View project on GitHub">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.52 2.87 8.36 6.84 9.72.5.1.68-.22.68-.49 0-.24-.01-.87-.01-1.71-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.1-1.5-1.1-1.5-.9-.63.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.37-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.3 9.3 0 0 1 5 0c1.9-1.32 2.74-1.05 2.74-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.06.36.33.68.97.68 1.96 0 1.42-.01 2.56-.01 2.9 0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2Z" fill="currentColor" />
-            </svg>
+            <span class="project-icon-link__front" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                <path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.52 2.87 8.36 6.84 9.72.5.1.68-.22.68-.49 0-.24-.01-.87-.01-1.71-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.1-1.5-1.1-1.5-.9-.63.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.37-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.3 9.3 0 0 1 5 0c1.9-1.32 2.74-1.05 2.74-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.06.36.33.68.97.68 1.96 0 1.42-.01 2.56-.01 2.9 0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2Z" fill="currentColor" />
+              </svg>
+            </span>
             <span class="sr-only">View on GitHub</span>
           </a>
         </div>


### PR DESCRIPTION
## Summary
- wrap the GitHub project link icon in a raised front span so the anchor provides the pushable base
- restyle the GitHub icon link to use the same 3D base, raised face, and interactive states as the launch button

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4f2f9cd8c832e8cea7fa7d6de2ed0