### PR TITLE
Swap desktop positions for experience and extracurricular windows

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,9 +568,10 @@
     /* --- Experience Window --- */
     .experience-window {
       width: 480px;
-      top: 540px;
-      left: 37%;
-      transform: translateX(-50%);
+      top: 100px;
+      right: 80px;
+      left: auto;
+      transform: none;
       z-index: 7;
       max-height: 350px;
     }
@@ -734,8 +735,9 @@
     /* --- Extracurriculars Window --- */
     .extra-window {
       width: 380px;
-      top: 100px;
-      right: 80px;
+      top: 540px;
+      left: 37%;
+      transform: translateX(-50%);
       z-index: 4;
       max-height: 380px;
     }
@@ -745,6 +747,10 @@
     }
 
     .experience-window:hover {
+      transform: translateY(-2px);
+    }
+
+    .extra-window:hover {
       transform: translateX(-50%) translateY(-2px);
     }
 


### PR DESCRIPTION
## Summary
- move the desktop placement of the experience.txt window to the upper right corner
- relocate the Extracurriculars window to the lower center position with its original centered hover effect
- adjust hover animations so each window animates correctly in its new location

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4f9a7c1dc832ebbc3a41bdf8e5c9d