### PR TITLE
Wrap window content in inner frame for hover lift

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,12 +71,23 @@
       border-radius: 8px;
       box-shadow: var(--window-shadow);
       overflow: hidden;
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      transition: box-shadow 0.2s ease;
+    }
+
+    .window-frame {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      transition: transform 0.2s ease;
     }
 
     .window:hover {
-      transform: translateY(-2px);
       box-shadow: 0 12px 32px rgba(74, 14, 61, 0.2);
+    }
+
+    .window:hover .window-frame {
+      transform: translateY(-2px);
     }
 
     .window-titlebar {
@@ -201,8 +212,11 @@
     }
 
     .facetime-window:hover {
-      transform: translateX(-50%);
       box-shadow: var(--window-shadow);
+    }
+
+    .facetime-window:hover .window-frame {
+      transform: translateY(0);
     }
 
     .facetime-content {
@@ -746,12 +760,9 @@
       max-height: 360px;
     }
 
-    .experience-window:hover {
+    .experience-window:hover .window-frame,
+    .extra-window:hover .window-frame {
       transform: translateY(-2px);
-    }
-
-    .extra-window:hover {
-      transform: translateX(-50%) translateY(-2px);
     }
 
     /* --- Dock --- */
@@ -1034,8 +1045,8 @@
       z-index: 950;
     }
 
-    .project-window:hover {
-      transform: translate(-50%, -2px);
+    .project-window:hover .window-frame {
+      transform: translateY(-2px);
     }
 
     .project-actions {
@@ -1975,306 +1986,320 @@
 
     <!-- FaceTime Window (Avatar) -->
     <div class="window facetime-window">
-      <div class="window-titlebar">
-        <div class="window-controls">
-          <div class="window-button close"></div>
-          <div class="window-button minimize"></div>
-          <div class="window-button maximize"></div>
-        </div>
-        <div class="window-title">Rhea is calling...</div>
-        <div class="theme-toggle active" id="themeToggle" title="Toggle day/night">
-          <span class="theme-toggle-icon moon">⏾</span>
-          <span class="theme-toggle-icon sun">𖤓</span>
-          <div class="theme-toggle-knob"></div>
-        </div>
-      </div>
-      <div class="window-content facetime-content">
-        <div class="avatar-stage" id="stage">
-          <div class="avatar-loading" id="avatarLoading" role="status" aria-live="polite">
-            <div class="avatar-spinner" aria-hidden="true"></div>
-            <span class="sr-only">Loading avatar experience…</span>
+      <div class="window-frame">
+        <div class="window-titlebar">
+          <div class="window-controls">
+            <div class="window-button close"></div>
+            <div class="window-button minimize"></div>
+            <div class="window-button maximize"></div>
           </div>
-          <div class="pupil-backdrop"></div>
-          <div class="pupil left" id="pupilL"></div>
-          <div class="pupil right" id="pupilR"></div>
-          <img class="avatar" id="avatarImg" src="assets/avatar_no-eyes.png" alt="Rhea Singh avatar" />
-          <div class="speech-bubble speech-bubble--initial">hello world!</div>
+          <div class="window-title">Rhea is calling...</div>
+          <div class="theme-toggle active" id="themeToggle" title="Toggle day/night">
+            <span class="theme-toggle-icon moon">⏾</span>
+            <span class="theme-toggle-icon sun">𖤓</span>
+            <div class="theme-toggle-knob"></div>
+          </div>
         </div>
-        <div class="avatar-info">
-          <div class="avatar-name">Rhea Singh</div>
-          <div class="avatar-subtitle">Software Engineer · Product/UX</div>
-        </div>
-        <!-- Location Footer -->
-        <div class="location-footer">
-          <span class="online-indicator"></span>
-          <span style="font-weight:300;">Open to roles in <span id="sfLocation">SF</span> | <span id="nycLocation">NYC</span> | <span id="nonusLocation">Remote or non-US</span></span>
+        <div class="window-content facetime-content">
+          <div class="avatar-stage" id="stage">
+            <div class="avatar-loading" id="avatarLoading" role="status" aria-live="polite">
+              <div class="avatar-spinner" aria-hidden="true"></div>
+              <span class="sr-only">Loading avatar experience…</span>
+            </div>
+            <div class="pupil-backdrop"></div>
+            <div class="pupil left" id="pupilL"></div>
+            <div class="pupil right" id="pupilR"></div>
+            <img class="avatar" id="avatarImg" src="assets/avatar_no-eyes.png" alt="Rhea Singh avatar" />
+            <div class="speech-bubble speech-bubble--initial">hello world!</div>
+          </div>
+          <div class="avatar-info">
+            <div class="avatar-name">Rhea Singh</div>
+            <div class="avatar-subtitle">Software Engineer · Product/UX</div>
+          </div>
+          <!-- Location Footer -->
+          <div class="location-footer">
+            <span class="online-indicator"></span>
+            <span style="font-weight:300;">Open to roles in <span id="sfLocation">SF</span> | <span id="nycLocation">NYC</span> | <span id="nonusLocation">Remote or non-US</span></span>
+          </div>
         </div>
       </div>
     </div>
-
     <!-- Terminal Window -->
     <div class="window terminal-window">
-      <div class="window-titlebar">
-        <div class="window-controls">
-          <div class="window-button close"></div>
-          <div class="window-button minimize"></div>
-          <div class="window-button maximize"></div>
+      <div class="window-frame">
+        <div class="window-titlebar">
+          <div class="window-controls">
+            <div class="window-button close"></div>
+            <div class="window-button minimize"></div>
+            <div class="window-button maximize"></div>
+          </div>
+          <div class="window-title">terminal</div>
         </div>
-        <div class="window-title">terminal</div>
-      </div>
-      <div class="window-content">
-        <div class="terminal-prompt">$ status --now</div>
-        <div class="terminal-status">
-          <span class="terminal-bullet">◉</span>
-          <span class="terminal-label">working_on</span>
-          <span class="terminal-value">a Sunday crossword</span>
-        </div>
-        <div class="terminal-status">
-          <span class="terminal-bullet">◉</span>
-          <span class="terminal-label">reading</span>
-          <span class="terminal-value">Dune Messiah</span>
-        </div>
-        <div style="margin-top: 8px; color: #5c6370;">
-          $<span class="terminal-cursor"></span>
+        <div class="window-content">
+          <div class="terminal-prompt">$ status --now</div>
+          <div class="terminal-status">
+            <span class="terminal-bullet">◉</span>
+            <span class="terminal-label">working_on</span>
+            <span class="terminal-value">a Sunday crossword</span>
+          </div>
+          <div class="terminal-status">
+            <span class="terminal-bullet">◉</span>
+            <span class="terminal-label">reading</span>
+            <span class="terminal-value">Dune Messiah</span>
+          </div>
+          <div style="margin-top: 8px; color: #5c6370;">
+            $<span class="terminal-cursor"></span>
+          </div>
         </div>
       </div>
     </div>
 
     <!-- About/Education Window -->
     <div class="window about-window">
-      <div class="window-titlebar">
-        <div class="window-controls">
-          <div class="window-button close"></div>
-          <div class="window-button minimize"></div>
-          <div class="window-button maximize"></div>
+      <div class="window-frame">
+        <div class="window-titlebar">
+          <div class="window-controls">
+            <div class="window-button close"></div>
+            <div class="window-button minimize"></div>
+            <div class="window-button maximize"></div>
+          </div>
+          <div class="window-title">education.txt</div>
+          <div style="width: 54px;"></div>
         </div>
-        <div class="window-title">education.txt</div>
-        <div style="width: 54px;"></div>
-      </div>
-      <div class="window-content">
-        <div class="info-block">
-          <div class="info-title">University of Michigan, College of Engineering</div>
-          <div class="info-subtitle">B.S. in Computer Science, History Minor</div>
-          <div class="info-meta">2016 - 2020 | Ann Arbor, MI</div>
-          <ul class="info-list">
-            <li>Operating Systems, Web Systems, UI Development, Computer Security</li>
-            <li>Data Structures & Algs, Foundations of Computer Science</li>
-            <li>Computer Architecture, Discrete Math, Linear Algebra, Differential Equations</li>
-          </ul>
+        <div class="window-content">
+          <div class="info-block">
+            <div class="info-title">University of Michigan, College of Engineering</div>
+            <div class="info-subtitle">B.S. in Computer Science, History Minor</div>
+            <div class="info-meta">2016 - 2020 | Ann Arbor, MI</div>
+            <ul class="info-list">
+              <li>Operating Systems, Web Systems, UI Development, Computer Security</li>
+              <li>Data Structures & Algs, Foundations of Computer Science</li>
+              <li>Computer Architecture, Discrete Math, Linear Algebra, Differential Equations</li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>
 
     <!-- Experience Window -->
     <div class="window experience-window">
-      <div class="window-titlebar">
-        <div class="window-controls">
-          <div class="window-button close"></div>
-          <div class="window-button minimize"></div>
-          <div class="window-button maximize"></div>
-        </div>
-        <div class="window-title">experience.txt</div>
-        <div style="width: 54px;"></div>
-      </div>
-      <div class="window-content">
-        <div class="job-item">
-          <div class="job-header">
-            <div>
-              <div class="job-company">Apple, Health & Fitness</div>
-              <div class="job-role">Software Engineer</div>
-            </div>
-            <div class="job-date">Aug 2020 - Sept 2025<br>Cupertino, CA</div>
+      <div class="window-frame">
+        <div class="window-titlebar">
+          <div class="window-controls">
+            <div class="window-button close"></div>
+            <div class="window-button minimize"></div>
+            <div class="window-button maximize"></div>
           </div>
-          <ul class="info-list">
-            <li>Designed scalable system architectures to power new Health features and improve algorithm performance on iOS and watchOS</li>
-            <li>Collaborated with research scientists and cross-functional teams to run FDA-regulated studies as part of a multi-year flagship feature</li>
-            <li>Built and owned research apps to test experimental Health & Fitness features and collect secure, high-fidelity sensor data</li>
-            <li>Architected efficient APIs and background systems balancing power, performance, and resource constraints</li>
-            <li>Coordinated priorities across data, infrastructure, and product teams to meet ambitious delivery goals</li>
-            <li>Presented designs and trade-offs to executives and experts to align on technical direction</li>
-          </ul>
+          <div class="window-title">experience.txt</div>
+          <div style="width: 54px;"></div>
         </div>
+        <div class="window-content">
+          <div class="job-item">
+            <div class="job-header">
+              <div>
+                <div class="job-company">Apple, Health & Fitness</div>
+                <div class="job-role">Software Engineer</div>
+              </div>
+              <div class="job-date">Aug 2020 - Sept 2025<br>Cupertino, CA</div>
+            </div>
+            <ul class="info-list">
+              <li>Designed scalable system architectures to power new Health features and improve algorithm performance on iOS and watchOS</li>
+              <li>Collaborated with research scientists and cross-functional teams to run FDA-regulated studies as part of a multi-year flagship feature</li>
+              <li>Built and owned research apps to test experimental Health & Fitness features and collect secure, high-fidelity sensor data</li>
+              <li>Architected efficient APIs and background systems balancing power, performance, and resource constraints</li>
+              <li>Coordinated priorities across data, infrastructure, and product teams to meet ambitious delivery goals</li>
+              <li>Presented designs and trade-offs to executives and experts to align on technical direction</li>
+            </ul>
+          </div>
 
-        <div class="job-item">
-          <div class="job-header">
-            <div>
-              <div class="job-company">Capital One</div>
-              <div class="job-role">Tech Intern</div>
+          <div class="job-item">
+            <div class="job-header">
+              <div>
+                <div class="job-company">Capital One</div>
+                <div class="job-role">Tech Intern</div>
+              </div>
+              <div class="job-date">June - Aug 2019<br>Chicago, IL</div>
             </div>
-            <div class="job-date">June - Aug 2019<br>Chicago, IL</div>
+            <ul class="info-list">
+              <li>Improved user experience for new partnership application based on feedback from previous rollouts</li>
+              <li>Developed metrics for team efficiency in the development process</li>
+              <li>Designed a beautiful, easy-to-understand data visualization tool of team's Github pull request process</li>
+            </ul>
           </div>
-          <ul class="info-list">
-            <li>Improved user experience for new partnership application based on feedback from previous rollouts</li>
-            <li>Developed metrics for team efficiency in the development process</li>
-            <li>Designed a beautiful, easy-to-understand data visualization tool of team's Github pull request process</li>
-          </ul>
-        </div>
 
-        <div class="job-item">
-          <div class="job-header">
-            <div>
-              <div class="job-company">Blablablab (UMich)</div>
-              <div class="job-role"><i>The Bringing together Language and Behavior for Large-scale Analytical Breakthroughs Laboratory</i></div>
-              <div class="job-role">Undergraduate Researcher</div>
+          <div class="job-item">
+            <div class="job-header">
+              <div>
+                <div class="job-company">Blablablab (UMich)</div>
+                <div class="job-role"><i>The Bringing together Language and Behavior for Large-scale Analytical Breakthroughs Laboratory</i></div>
+                <div class="job-role">Undergraduate Researcher</div>
+              </div>
+              <div class="job-date">2018 - 2020<br>Ann Arbor, MI</div>
             </div>
-            <div class="job-date">2018 - 2020<br>Ann Arbor, MI</div>
+            <ul class="info-list">
+              <li>Scraped Wikipedia for all people with pages and identified gender based on names and pronouns</li>
+              <li>Applied NLP techniques to derive statistically significant differences in language used dependent on gender</li>
+              <li>Thought critically in collaboration with professor about data and potential biases</li>
+            </ul>
           </div>
-          <ul class="info-list">
-            <li>Scraped Wikipedia for all people with pages and identified gender based on names and pronouns</li>
-            <li>Applied NLP techniques to derive statistically significant differences in language used dependent on gender</li>
-            <li>Thought critically in collaboration with professor about data and potential biases</li>
-          </ul>
         </div>
       </div>
     </div>
 
     <!-- Skills Window -->
     <div class="window skills-window">
-      <div class="window-titlebar">
-        <div class="window-controls">
-          <div class="window-button close"></div>
-          <div class="window-button minimize"></div>
-          <div class="window-button maximize"></div>
+      <div class="window-frame">
+        <div class="window-titlebar">
+          <div class="window-controls">
+            <div class="window-button close"></div>
+            <div class="window-button minimize"></div>
+            <div class="window-button maximize"></div>
+          </div>
+          <div class="window-title">/Users/rhea/skills/</div>
+          <div style="width: 54px;"></div>
         </div>
-        <div class="window-title">/Users/rhea/skills/</div>
-        <div style="width: 54px;"></div>
-      </div>
-      <div class="window-content">
-        <div class="file-explorer">
-          <!-- Backend Folder -->
-          <div class="folder">
-            <div class="folder-header" onclick="toggleFolder(this)">
-              <span class="folder-arrow">▼</span>
-              <img src="assets/icon-folder.png" alt="" class="folder-icon" />
-              <span class="folder-name">backend</span>
+        <div class="window-content">
+          <div class="file-explorer">
+            <!-- Backend Folder -->
+            <div class="folder">
+              <div class="folder-header" onclick="toggleFolder(this)">
+                <span class="folder-arrow">▼</span>
+                <img src="assets/icon-folder.png" alt="" class="folder-icon" />
+                <span class="folder-name">backend</span>
+              </div>
+              <div class="folder-content">
+                <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .cpp</div>
+                <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .py</div>
+                <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .sql</div>
+                <div class="file"><span class="file-icon">●</span> API + SDK Development</div>
+                <div class="file"><span class="file-icon">●</span> Multithreaded OS</div>
+              </div>
             </div>
-            <div class="folder-content">
-              <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .cpp</div>
-              <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .py</div>
-              <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .sql</div>
-              <div class="file"><span class="file-icon">●</span> API + SDK Development</div>
-              <div class="file"><span class="file-icon">●</span> Multithreaded OS</div>
-            </div>
-          </div>
 
-          <!-- Frontend Folder -->
-          <div class="folder">
-            <div class="folder-header" onclick="toggleFolder(this)">
-              <span class="folder-arrow">▼</span>
-              <img src="assets/icon-folder.png" alt="" class="folder-icon" />
-              <span class="folder-name">frontend</span>
+            <!-- Frontend Folder -->
+            <div class="folder">
+              <div class="folder-header" onclick="toggleFolder(this)">
+                <span class="folder-arrow">▼</span>
+                <img src="assets/icon-folder.png" alt="" class="folder-icon" />
+                <span class="folder-name">frontend</span>
+              </div>
+              <div class="folder-content">
+                <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .swift</div>
+                <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .m/.mm</div>
+                <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .html</div>
+                <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .css</div>
+                <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .js</div>
+                <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .react</div>
+                <div class="file"><span class="file-icon">●</span> iOS + Xcode</div>
+              </div>
             </div>
-            <div class="folder-content">
-              <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .swift</div>
-              <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .m/.mm</div>
-              <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .html</div>
-              <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .css</div>
-              <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .js</div>
-              <div class="file"><img src="assets/icon-file.png" alt="" class="folder-icon" /> .react</div>
-              <div class="file"><span class="file-icon">●</span> iOS + Xcode</div>
-            </div>
-          </div>
         </div>
       </div>
     </div>
+  </div>
 
     <!-- Extracurriculars Window -->
     <div class="window extra-window">
-      <div class="window-titlebar">
-        <div class="window-controls">
-          <div class="window-button close"></div>
-          <div class="window-button minimize"></div>
-          <div class="window-button maximize"></div>
-        </div>
-        <div class="window-title">Extracurriculars</div>
-        <div style="width: 54px;"></div>
-      </div>
-      <div class="window-content">
-        <div class="job-item">
-          <div class="job-header">
-            <div>
-              <div class="job-company">ICPC (Programming Contest)</div>
-              <div class="job-role">Participant</div>
-            </div>
-            <div class="job-date">Sept 2018 - 2020</div>
+      <div class="window-frame">
+        <div class="window-titlebar">
+          <div class="window-controls">
+            <div class="window-button close"></div>
+            <div class="window-button minimize"></div>
+            <div class="window-button maximize"></div>
           </div>
-          <ul class="info-list">
-            <li>Qualified for ICPC State Level with team of three</li>
-            <li>Placed in top five, working on challenging programming questions</li>
-          </ul>
+          <div class="window-title">Extracurriculars</div>
+          <div style="width: 54px;"></div>
         </div>
+        <div class="window-content">
+          <div class="job-item">
+            <div class="job-header">
+              <div>
+                <div class="job-company">ICPC (Programming Contest)</div>
+                <div class="job-role">Participant</div>
+              </div>
+              <div class="job-date">Sept 2018 - 2020</div>
+            </div>
+            <ul class="info-list">
+              <li>Qualified for ICPC State Level with team of three</li>
+              <li>Placed in top five, working on challenging programming questions</li>
+            </ul>
+          </div>
 
-        <div class="job-item">
-          <div class="job-header">
-            <div>
-              <div class="job-company">Michigan Research Community</div>
-              <div class="job-role">Peer Mentor</div>
+          <div class="job-item">
+            <div class="job-header">
+              <div>
+                <div class="job-company">Michigan Research Community</div>
+                <div class="job-role">Peer Mentor</div>
+              </div>
+              <div class="job-date">Sept 2016 - May 2018</div>
             </div>
-            <div class="job-date">Sept 2016 - May 2018</div>
+            <ul class="info-list">
+              <li>Guided first-time undergraduate research students in navigating project search and research path</li>
+              <li>Provided support, monthly meetings, and guidance with research posters</li>
+            </ul>
           </div>
-          <ul class="info-list">
-            <li>Guided first-time undergraduate research students in navigating project search and research path</li>
-            <li>Provided support, monthly meetings, and guidance with research posters</li>
-          </ul>
         </div>
       </div>
     </div>
+  </div>
 
     <!-- Project Windows (Hidden by default) -->
     <!-- NYT Spelling Bee Project Window -->
     <div class="window project-window" id="spellingBeeWindow">
-      <div class="window-titlebar">
-        <div class="window-controls">
-          <div class="window-button close" onclick="closeProjectWindow('spellingBeeWindow')"></div>
-          <div class="window-button minimize"></div>
-          <div class="window-button maximize"></div>
-        </div>
-        <div class="window-title">spelling-bee</div>
-        <div style="width: 54px;"></div>
-      </div>
-      <div class="window-content">
-        <div class="section-heading">Project Overview</div>
-        <p style="font-size: 13px; line-height: 1.6; color: var(--text-dark); margin-bottom: 12px;">
-          A real-time interactive version of the New York Times Spelling Bee made to compete with friends and family. Updates daily when the new puzzle drops.
-        </p>
-        <div class="project-actions">
-          <a href="https://frankies-spelling-bee.vercel.app" class="project-launch" target="_blank">
-            <span class="project-launch__front">
-              <span>Launch</span>
-              <span aria-hidden="true">🚀</span>
-            </span>
-          </a>
-          <a href="https://github.com/rhea-s/spelling-bee/tree/main" class="project-icon-link" target="_blank" aria-label="View project on GitHub">
-            <span class="project-icon-link__front" aria-hidden="true">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                <path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.52 2.87 8.36 6.84 9.72.5.1.68-.22.68-.49 0-.24-.01-.87-.01-1.71-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.1-1.5-1.1-1.5-.9-.63.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.37-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.3 9.3 0 0 1 5 0c1.9-1.32 2.74-1.05 2.74-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.06.36.33.68.97.68 1.96 0 1.42-.01 2.56-.01 2.9 0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2Z" fill="currentColor" />
-              </svg>
-            </span>
-            <span class="sr-only">View on GitHub</span>
-          </a>
-        </div>
-        <div class="section-heading">Tech Stack</div>
-        <div class="skill-tags" style="margin-bottom: 16px;">
-          <span class="skill-tag">JavaScript</span>
-          <span class="skill-tag">CSS</span>
-          <span class="skill-tag">Python Scripting</span>
-          <span class="skill-tag">Firebase</span>
-          <span class="skill-tag">Claude Code</span>
-          <!-- Add more tech stack tags as needed -->
-        </div>
-
-        <div class="section-heading">Screenshots</div>
-        <div class="screenshot-gallery">
-          <div class="phone-mockup">
-            <div class="phone-notch"></div>
-            <div class="phone-screen">
-              <img src="assets/spellingbee-ex1.PNG" alt="Spelling Bee Screenshot 1" />
-            </div>
+      <div class="window-frame">
+        <div class="window-titlebar">
+          <div class="window-controls">
+            <div class="window-button close" onclick="closeProjectWindow('spellingBeeWindow')"></div>
+            <div class="window-button minimize"></div>
+            <div class="window-button maximize"></div>
           </div>
-          <div class="phone-mockup">
-            <div class="phone-notch"></div>
-            <div class="phone-screen">
-              <img src="assets/spellingbee-ex2.PNG" alt="Spelling Bee Screenshot 2" />
+          <div class="window-title">spelling-bee</div>
+          <div style="width: 54px;"></div>
+        </div>
+        <div class="window-content">
+          <div class="section-heading">Project Overview</div>
+          <p style="font-size: 13px; line-height: 1.6; color: var(--text-dark); margin-bottom: 12px;">
+            A real-time interactive version of the New York Times Spelling Bee made to compete with friends and family. Updates daily when the new puzzle drops.
+          </p>
+          <div class="project-actions">
+            <a href="https://frankies-spelling-bee.vercel.app" class="project-launch" target="_blank">
+              <span class="project-launch__front">
+                <span>Launch</span>
+                <span aria-hidden="true">🚀</span>
+              </span>
+            </a>
+            <a href="https://github.com/rhea-s/spelling-bee/tree/main" class="project-icon-link" target="_blank" aria-label="View project on GitHub">
+              <span class="project-icon-link__front" aria-hidden="true">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                  <path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.52 2.87 8.36 6.84 9.72.5.1.68-.22.68-.49 0-.24-.01-.87-.01-1.71-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.1-1.5-1.1-1.5-.9-.63.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.37-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.3 9.3 0 0 1 5 0c1.9-1.32 2.74-1.05 2.74-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.06.36.33.68.97.68 1.96 0 1.42-.01 2.56-.01 2.9 0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2Z" fill="currentColor" />
+                </svg>
+              </span>
+              <span class="sr-only">View on GitHub</span>
+            </a>
+          </div>
+          <div class="section-heading">Tech Stack</div>
+          <div class="skill-tags" style="margin-bottom: 16px;">
+            <span class="skill-tag">JavaScript</span>
+            <span class="skill-tag">CSS</span>
+            <span class="skill-tag">Python Scripting</span>
+            <span class="skill-tag">Firebase</span>
+            <span class="skill-tag">Claude Code</span>
+            <!-- Add more tech stack tags as needed -->
+          </div>
+
+          <div class="section-heading">Screenshots</div>
+          <div class="screenshot-gallery">
+            <div class="phone-mockup">
+              <div class="phone-notch"></div>
+              <div class="phone-screen">
+                <img src="assets/spellingbee-ex1.PNG" alt="Spelling Bee Screenshot 1" />
+              </div>
+            </div>
+            <div class="phone-mockup">
+              <div class="phone-notch"></div>
+              <div class="phone-screen">
+                <img src="assets/spellingbee-ex2.PNG" alt="Spelling Bee Screenshot 2" />
+              </div>
             </div>
           </div>
         </div>
@@ -2283,40 +2308,44 @@
 
     <!-- Book Club Project Window -->
     <div class="window project-window" id="bookClubWindow">
-      <div class="window-titlebar">
-        <div class="window-controls">
-          <div class="window-button close" onclick="closeProjectWindow('bookClubWindow')"></div>
-          <div class="window-button minimize"></div>
-          <div class="window-button maximize"></div>
+      <div class="window-frame">
+        <div class="window-titlebar">
+          <div class="window-controls">
+            <div class="window-button close" onclick="closeProjectWindow('bookClubWindow')"></div>
+            <div class="window-button minimize"></div>
+            <div class="window-button maximize"></div>
+          </div>
+          <div class="window-title">book-club</div>
+          <div style="width: 54px;"></div>
         </div>
-        <div class="window-title">book-club</div>
-        <div style="width: 54px;"></div>
-      </div>
-      <div class="window-content">
-        <div style="text-align: center; padding: 40px 20px;">
-          <p style="font-size: 18px; font-weight: 600; color: var(--text-dark); margin-bottom: 8px;">
-            🚧 Under Construction 🚧
-          </p>
-          <p style="font-size: 13px; color: var(--text-muted);">
-            Check back soon!
-          </p>
+        <div class="window-content">
+          <div style="text-align: center; padding: 40px 20px;">
+            <p style="font-size: 18px; font-weight: 600; color: var(--text-dark); margin-bottom: 8px;">
+              🚧 Under Construction 🚧
+            </p>
+            <p style="font-size: 13px; color: var(--text-muted);">
+              Check back soon!
+            </p>
+          </div>
         </div>
       </div>
     </div>
 
     <!-- Work Window (Finder-style project grid) -->
     <div class="window project-window" id="workWindow">
-      <div class="window-titlebar">
-        <div class="window-controls">
-          <div class="window-button close" onclick="closeProjectWindow('workWindow')"></div>
-          <div class="window-button minimize"></div>
-          <div class="window-button maximize"></div>
+      <div class="window-frame">
+        <div class="window-titlebar">
+          <div class="window-controls">
+            <div class="window-button close" onclick="closeProjectWindow('workWindow')"></div>
+            <div class="window-button minimize"></div>
+            <div class="window-button maximize"></div>
+          </div>
+          <div class="window-title">apple-work</div>
+          <div style="width: 54px;"></div>
         </div>
-        <div class="window-title">apple-work</div>
-        <div style="width: 54px;"></div>
-      </div>
-      <div class="window-content">
-        <div class="project-grid" id="appleProjectGrid" role="list"></div>
+        <div class="window-content">
+          <div class="project-grid" id="appleProjectGrid" role="list"></div>
+        </div>
       </div>
     </div>
 
@@ -3057,7 +3086,11 @@
         }
       }
 
-      windowEl.append(titlebar, content);
+      const frame = document.createElement('div');
+      frame.className = 'window-frame';
+      frame.append(titlebar, content);
+
+      windowEl.appendChild(frame);
       return windowEl;
     }
 


### PR DESCRIPTION
## Summary
- wrap desktop window markup in a new `.window-frame` container so titlebar and content lift together without breaking overflow clipping
- move hover translate rules onto `.window-frame` for standard and project windows and update the dynamic Apple project builder accordingly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e50071d110832eac76eaa534621b70