### PR TITLE
Update Apple popup and spelling bee button styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1085,7 +1085,7 @@
       position: absolute;
       inset: 0;
       border-radius: inherit;
-      background: linear-gradient(180deg, rgba(71, 8, 45, 0.95), rgba(122, 21, 74, 0.9));
+      background: #c54b7f;
       transform: translateY(4px);
       transition: transform 0.2s var(--micro-ease), filter 0.2s ease;
       z-index: 0;
@@ -1098,7 +1098,7 @@
       gap: 6px;
       padding: 10px 20px;
       border-radius: inherit;
-      background: linear-gradient(135deg, #ffe3ef 0%, #f48fb1 45%, #f06292 100%);
+      background: #f06292;
       color: white;
       font-size: 13px;
       font-weight: 600;
@@ -1151,7 +1151,7 @@
       position: absolute;
       inset: 0;
       border-radius: inherit;
-      background: linear-gradient(180deg, rgba(71, 8, 45, 0.95), rgba(122, 21, 74, 0.9));
+      background: #c54b7f;
       transform: translateY(4px);
       transition: transform 0.2s var(--micro-ease), filter 0.2s ease;
       z-index: 0;
@@ -1165,7 +1165,7 @@
       width: 100%;
       height: 100%;
       border-radius: inherit;
-      background: linear-gradient(135deg, #ffe3ef 0%, #f48fb1 45%, #f06292 100%);
+      background: #f06292;
       color: white;
       transform: translateY(-6px);
       transition: transform 0.2s var(--micro-ease), filter 0.2s ease;
@@ -1271,7 +1271,7 @@
 
     .iphone-screen {
       position: relative;
-      background: linear-gradient(160deg, #1a2240 0%, #202954 35%, #161225 100%);
+      background: #1c1c1e;
       border-radius: 32px;
       padding: 18px 18px 48px;
       min-height: 560px;


### PR DESCRIPTION
## Summary
- switch the simulated iPhone screen in the Apple work window to a solid charcoal background
- update the spelling bee launch and GitHub buttons to use a solid theme pink instead of gradients

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e58c2d7908832e846e149fc791e128