### PR TITLE
Update Apple popup and spelling bee button styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1085,7 +1085,7 @@
       position: absolute;
       inset: 0;
       border-radius: inherit;
-      background: linear-gradient(180deg, rgba(71, 8, 45, 0.95), rgba(122, 21, 74, 0.9));
+      background: #c54b7f;
       transform: translateY(4px);
       transition: transform 0.2s var(--micro-ease), filter 0.2s ease;
       z-index: 0;
@@ -1098,7 +1098,7 @@
       gap: 6px;
       padding: 10px 20px;
       border-radius: inherit;
-      background: linear-gradient(135deg, #ffe3ef 0%, #f48fb1 45%, #f06292 100%);
+      background: #f06292;
       color: white;
       font-size: 13px;
       font-weight: 600;
@@ -1151,7 +1151,7 @@
       position: absolute;
       inset: 0;
       border-radius: inherit;
-      background: linear-gradient(180deg, rgba(71, 8, 45, 0.95), rgba(122, 21, 74, 0.9));
+      background: #c54b7f;
       transform: translateY(4px);
       transition: transform 0.2s var(--micro-ease), filter 0.2s ease;
       z-index: 0;
@@ -1165,7 +1165,7 @@
       width: 100%;
       height: 100%;
       border-radius: inherit;
-      background: linear-gradient(135deg, #ffe3ef 0%, #f48fb1 45%, #f06292 100%);
+      background: #f06292;
       color: white;
       transform: translateY(-6px);
       transition: transform 0.2s var(--micro-ease), filter 0.2s ease;
@@ -1271,15 +1271,36 @@
 
     .iphone-screen {
       position: relative;
-      background: linear-gradient(160deg, #1a2240 0%, #202954 35%, #161225 100%);
+      background:
+        radial-gradient(circle at 25% 18%, rgba(255, 232, 152, 0.88) 0%, rgba(255, 232, 152, 0) 55%),
+        radial-gradient(circle at 30% 74%, rgba(255, 133, 198, 0.85) 0%, rgba(255, 133, 198, 0) 60%),
+        radial-gradient(circle at 78% 70%, rgba(126, 221, 255, 0.85) 0%, rgba(126, 221, 255, 0) 60%),
+        radial-gradient(circle at 78% 28%, rgba(255, 182, 120, 0.8) 0%, rgba(255, 182, 120, 0) 55%),
+        #f7f1ff;
       border-radius: 32px;
       padding: 18px 18px 48px;
       min-height: 560px;
       display: flex;
       flex-direction: column;
       gap: 16px;
-      color: #f5f5f7;
+      color: #fefefe;
+      text-shadow: 0 1px 6px rgba(16, 16, 32, 0.35);
       overflow: hidden;
+      isolation: isolate;
+    }
+
+    .iphone-screen::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(180deg, rgba(16, 16, 32, 0.16) 0%, rgba(16, 16, 32, 0.28) 100%);
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    .iphone-screen > * {
+      position: relative;
+      z-index: 1;
     }
 
     .iphone-status-bar {


### PR DESCRIPTION
## Summary
- switch the simulated iPhone screen in the Apple work window to a multicolor gradient that mimics the default wallpaper
- update the spelling bee launch and GitHub buttons to use a solid theme pink instead of gradients

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e58c2d7908832e846e149fc791e128